### PR TITLE
Adds a unit test to prove that https://jira.duraspace.org/browse/DURA…

### DIFF
--- a/synctool/src/main/java/org/duracloud/sync/mgmt/ChangedFile.java
+++ b/synctool/src/main/java/org/duracloud/sync/mgmt/ChangedFile.java
@@ -36,7 +36,7 @@ public class ChangedFile implements Serializable {
     }
     
     /**
-     * Removes a previously reserved from the ChangedList. 
+     * Removes a previously reserved file from the ChangedList. 
      */
     public void remove(){
         ChangedList.getInstance().remove(this);

--- a/synctool/src/main/java/org/duracloud/sync/mgmt/ChangedFile.java
+++ b/synctool/src/main/java/org/duracloud/sync/mgmt/ChangedFile.java
@@ -35,10 +35,17 @@ public class ChangedFile implements Serializable {
         syncAttempts++;
     }
     
+    /**
+     * Removes a previously reserved from the ChangedList. 
+     */
     public void remove(){
         ChangedList.getInstance().remove(this);
     }
 
+    /**
+     * Releases the reservation on the file (if still reserved)
+     * and returns it to the list of unreserved ChangedFiles.
+     */
     public void unreserve(){
         ChangedList.getInstance().unreserve(this);
     }

--- a/synctool/src/main/java/org/duracloud/sync/mgmt/ChangedList.java
+++ b/synctool/src/main/java/org/duracloud/sync/mgmt/ChangedList.java
@@ -107,7 +107,7 @@ public class ChangedList implements Serializable {
         return fileList.size() + reservedFiles.size();
     }
 
-    protected synchronized boolean addChangedFile(ChangedFile changedFile) {
+    synchronized boolean addChangedFile(ChangedFile changedFile) {
         File file = changedFile.getFile();
         if(fileExclusionManager.isExcluded(file)){
             return false;
@@ -268,13 +268,27 @@ public class ChangedList implements Serializable {
         return files;
     }
 
-    public synchronized void  remove(ChangedFile changedFile) {
+    /**
+     * Removes a previously reserved ChangedFile from the list of
+     * reserved files, effectively removing it from the ChangedList. 
+     * However if this instance of the ChangedFile or a new 
+     * ChangedFile with an identical file path is re-added to the ChangedList 
+     * before the reserved file is removed,  calling remove will only remove 
+     * the changed file from the reserved list.
+     * @param changedFile
+     */
+    synchronized void  remove(ChangedFile changedFile) {
        this.reservedFiles.remove(getKey(changedFile));
     }
     
-    public synchronized void  unreserve(ChangedFile changedFile){
+    /**
+     * Releases the reservation on the file (if still reserved) and returns 
+     * it to the list.
+     * @param changedFile
+     */
+    synchronized void  unreserve(ChangedFile changedFile){
         ChangedFile removedFile = this.reservedFiles.remove(getKey(changedFile));
-        if(removedFile != null){
+        if(removedFile != null && !this.fileList.containsKey(getKey(removedFile))){
             addChangedFile(removedFile);
         }
     }

--- a/synctool/src/test/java/org/duracloud/sync/mgmt/SyncWorkerTest.java
+++ b/synctool/src/test/java/org/duracloud/sync/mgmt/SyncWorkerTest.java
@@ -1,0 +1,61 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.sync.mgmt;
+
+import java.io.File;
+
+import org.duracloud.sync.endpoint.MonitoredFile;
+import org.duracloud.sync.endpoint.SyncEndpoint;
+import org.duracloud.sync.endpoint.SyncResultType;
+import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockSupport;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.Assert.*;
+import static org.easymock.EasyMock.*;
+
+/**
+ * 
+ * @author Daniel Bernstein
+ * @since July 29, 2017
+ *
+ */
+@RunWith(EasyMockRunner.class)
+public class SyncWorkerTest extends EasyMockSupport{
+
+    @Before
+    public void setup(){
+        
+    }
+    
+    @After
+    public void teardown(){
+        verifyAll();
+    }
+    @Test
+    public void testDuracloud1131(){
+        //test the fact that retries are not occurring as expected on error.
+        assertEquals(0,ChangedList.getInstance().getListSizeIncludingReservedFiles());
+        ChangedList.getInstance().addChangedFile(new File("path"));
+        assertEquals(1,ChangedList.getInstance().getListSizeIncludingReservedFiles());
+        ChangedFile changedFile = ChangedList.getInstance().reserve();
+        assertEquals(0,ChangedList.getInstance().getListSize());
+        assertEquals(1,ChangedList.getInstance().getListSizeIncludingReservedFiles());
+        File watchDir = createMock(File.class);
+        SyncEndpoint endpoint = createMock(SyncEndpoint.class);
+        expect(endpoint.syncFileAndReturnDetailedResult(isA(MonitoredFile.class), isA(File.class))).andReturn(SyncResultType.FAILED);
+        replayAll();
+        SyncWorker worker = new SyncWorker(changedFile, watchDir , endpoint);
+        worker.run();
+        assertEquals(1, ChangedList.getInstance().getListSizeIncludingReservedFiles());
+        
+    }
+}


### PR DESCRIPTION
…CLOUD-1131

was problem.  As it turns out,  the test confirmed that the retry logic works as expected.
However there was a corner case wherein a file that is re-added to the ChangedList while
the previously added file could possibly not receive the expected number of retries in the
event that the reserved file is unreserved.

Addresses: https://jira.duraspace.org/browse/DURACLOUD-1131