### PR TITLE
DURACLOUD-1141 Allow to use SNS and SQS services in region different than us-east-1

### DIFF
--- a/common-queue/src/main/java/org/duracloud/common/queue/aws/SQSTaskQueue.java
+++ b/common-queue/src/main/java/org/duracloud/common/queue/aws/SQSTaskQueue.java
@@ -31,7 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.amazonaws.services.sqs.model.BatchResultErrorEntry;
 import com.amazonaws.services.sqs.model.ChangeMessageVisibilityRequest;
 import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
@@ -62,7 +63,7 @@ import com.amazonaws.services.sqs.model.SendMessageRequest;
 public class SQSTaskQueue implements TaskQueue {
     private static Logger log = LoggerFactory.getLogger(SQSTaskQueue.class);
 
-    private AmazonSQSClient sqsClient;
+    private AmazonSQS sqsClient;
     private String queueName;
     private String queueUrl;
     private Integer visibilityTimeout;  // in seconds
@@ -79,10 +80,10 @@ public class SQSTaskQueue implements TaskQueue {
      * http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/AmazonSQSClient.html#AmazonSQSClient()
      */
     public SQSTaskQueue(String queueName) {
-        this(new AmazonSQSClient(), queueName);
+        this(AmazonSQSClientBuilder.defaultClient(), queueName);
     }
 
-    public SQSTaskQueue(AmazonSQSClient sqsClient, String queueName) {
+    public SQSTaskQueue(AmazonSQS sqsClient, String queueName) {
         this.sqsClient = sqsClient;
         this.queueName = queueName;
         this.queueUrl = getQueueUrl();

--- a/common-sns/src/main/java/org/duracloud/common/sns/SnsSubscriptionManager.java
+++ b/common-sns/src/main/java/org/duracloud/common/sns/SnsSubscriptionManager.java
@@ -18,8 +18,10 @@ import org.duracloud.common.util.WaitUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClient;
 import com.amazonaws.services.sns.model.SubscribeResult;
+import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClient;
 import com.amazonaws.services.sqs.model.CreateQueueRequest;
 import com.amazonaws.services.sqs.model.CreateQueueResult;
@@ -38,16 +40,16 @@ import com.amazonaws.services.sqs.model.SetQueueAttributesRequest;
 public class SnsSubscriptionManager {
     private Logger log = LoggerFactory.getLogger(SnsSubscriptionManager.class);
 
-    private AmazonSQSClient sqsClient;
-    private AmazonSNSClient snsClient;
+    private AmazonSQS sqsClient;
+    private AmazonSNS snsClient;
     private String topicArn;
     private String queueName;
     private String queueUrl;
     private String subscriptionArn;
     private boolean initialized = false;
     private List<MessageListener> messageListeners = new ArrayList<>();
-    public SnsSubscriptionManager(AmazonSQSClient sqsClient,
-                                  AmazonSNSClient snsClient,
+    public SnsSubscriptionManager(AmazonSQS sqsClient,
+                                  AmazonSNS snsClient,
                                   String topicArn,
                                   String queueName) {
         this.topicArn = topicArn;
@@ -73,7 +75,8 @@ public class SnsSubscriptionManager {
         request.setAttributes(attributes);
         CreateQueueResult result;
         try { 
-            result = sqsClient.createQueue(request);
+        	System.out.println("XXXX");
+        	result = sqsClient.createQueue(request);
             this.queueUrl = result.getQueueUrl();
             log.info("sqs queue created: {}", this.queueUrl);
         }catch(QueueNameExistsException ex){

--- a/common-sns/src/main/java/org/duracloud/common/sns/config/SnsSubscriptionManagerConfig.java
+++ b/common-sns/src/main/java/org/duracloud/common/sns/config/SnsSubscriptionManagerConfig.java
@@ -27,8 +27,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.amazonaws.services.sqs.model.Message;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -56,9 +60,11 @@ public class SnsSubscriptionManagerConfig {
                                + Inet4Address.getLocalHost()
                                              .getHostName()
                                              .replace(".", "_");
-            SnsSubscriptionManager subscriptionManager =
-                new SnsSubscriptionManager(new AmazonSQSClient(),
-                                           new AmazonSNSClient(),
+            AmazonSQS sqsClient = AmazonSQSClientBuilder.defaultClient();
+			AmazonSNS snsClient = AmazonSNSClientBuilder.defaultClient();
+			SnsSubscriptionManager subscriptionManager =
+                new SnsSubscriptionManager(sqsClient,
+                                           snsClient,
                                            props.getInstanceNotificationTopicArn(),
                                            queueName);
 

--- a/common-sns/src/main/java/org/duracloud/common/sns/impl/AccountChangeNotifierImpl.java
+++ b/common-sns/src/main/java/org/duracloud/common/sns/impl/AccountChangeNotifierImpl.java
@@ -20,7 +20,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.amazonaws.services.sns.AmazonSNSClient;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 /**
  * 
  * @author Daniel Bernstein
@@ -29,7 +30,7 @@ import com.amazonaws.services.sns.AmazonSNSClient;
 @Component("accountChangeNotifier")
 public class AccountChangeNotifierImpl implements AccountChangeNotifier {
     
-    private AmazonSNSClient snsClient;
+    private AmazonSNS snsClient;
     
     private GlobalPropertiesRepo globalPropertiesRepo;
 
@@ -40,7 +41,7 @@ public class AccountChangeNotifierImpl implements AccountChangeNotifier {
      */
     @Autowired
     public AccountChangeNotifierImpl(GlobalPropertiesRepo globalPropertiesRepo) {
-        this.snsClient = new AmazonSNSClient();
+        this.snsClient = AmazonSNSClientBuilder.defaultClient();
         this.globalPropertiesRepo = globalPropertiesRepo;
     }
     


### PR DESCRIPTION
The SNS and SQS client were created using the deprecated Client constructor. This mean that only credentials can be picked up with the delegation AWS SDK process (JVM variables, env var, EC2 IAM Role).
The proposed changes allow to force the use of a region specifying an ENV var AWS_REGION or a aws.region JVM variable