### PR TITLE
DURACLOUD-1142 Allow to configure the region for the S3 Storage provider

### DIFF
--- a/durastore/src/main/java/org/duracloud/durastore/util/TaskProviderFactoryImpl.java
+++ b/durastore/src/main/java/org/duracloud/durastore/util/TaskProviderFactoryImpl.java
@@ -75,9 +75,9 @@ public class TaskProviderFactoryImpl extends ProviderFactoryBase
         TaskProvider taskProvider;
         if (type.equals(StorageProviderType.AMAZON_S3)) {
             S3StorageProvider unwrappedS3Provider =
-                new S3StorageProvider(username, password);
+                new S3StorageProvider(username, password, account.getOptions());
             AmazonS3Client s3Client =
-                S3ProviderUtil.getAmazonS3Client(username, password);
+                S3ProviderUtil.getAmazonS3Client(username, password, account.getOptions());
             AmazonCloudFrontClient cfClient =
                 S3ProviderUtil.getAmazonCloudFrontClient(username, password);
             Map<String, String> opts = account.getOptions();
@@ -99,7 +99,7 @@ public class TaskProviderFactoryImpl extends ProviderFactoryBase
             GlacierStorageProvider unwrappedGlacierProvider =
                 new GlacierStorageProvider(username, password);
             AmazonS3Client s3Client =
-                S3ProviderUtil.getAmazonS3Client(username, password);
+                S3ProviderUtil.getAmazonS3Client(username, password, account.getOptions());
             taskProvider = new GlacierTaskProvider(storageProvider,
                                                    unwrappedGlacierProvider,
                                                    s3Client, 
@@ -115,7 +115,7 @@ public class TaskProviderFactoryImpl extends ProviderFactoryBase
                     new ChronopolisStorageProvider(username, password);
             }
             AmazonS3Client s3Client =
-                S3ProviderUtil.getAmazonS3Client(username, password);
+                S3ProviderUtil.getAmazonS3Client(username, password, account.getOptions());
 
             String dcHost = storageAccountManager.getInstanceHost();
             String dcPort = storageAccountManager.getInstancePort();

--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
@@ -8,6 +8,7 @@
 package org.duracloud.s3storage;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.regions.Region;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.AccessControlList;
@@ -84,7 +85,7 @@ public class S3StorageProvider extends StorageProviderBase {
     protected AmazonS3Client s3Client = null;
 
     public S3StorageProvider(String accessKey, String secretKey) {
-        this(S3ProviderUtil.getAmazonS3Client(accessKey, secretKey),
+        this(S3ProviderUtil.getAmazonS3Client(accessKey, secretKey, null),
              accessKey,
              null);
     }
@@ -92,7 +93,7 @@ public class S3StorageProvider extends StorageProviderBase {
     public S3StorageProvider(String accessKey,
                              String secretKey,
                              Map<String, String> options) {
-        this(S3ProviderUtil.getAmazonS3Client(accessKey, secretKey),
+        this(S3ProviderUtil.getAmazonS3Client(accessKey, secretKey, options),
              accessKey,
              options);
     }

--- a/storageprovider/src/main/java/org/duracloud/storage/domain/StorageAccount.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/domain/StorageAccount.java
@@ -24,6 +24,7 @@ public interface StorageAccount {
         CF_ACCOUNT_ID,
         CF_KEY_ID,
         CF_KEY_PATH,
+        AWS_REGION,
         // iRODS below
         ZONE,
         PORT,


### PR DESCRIPTION
The S3StorageProvider now can specify as option the region to use. It is backward compatible, empty option are treat as before (default to us-east-1).

See also duracloud/management-console#7 for the changes required to the mgm console

This PR replaces #22 as it is against the develop branch instead than the master