### PR TITLE
DURACLOUD-1146 Allow to use SES service in any region with IAM role

### DIFF
--- a/notification-amazon/src/main/java/org/duracloud/notification/AmazonNotificationFactory.java
+++ b/notification-amazon/src/main/java/org/duracloud/notification/AmazonNotificationFactory.java
@@ -7,16 +7,19 @@
  */
 package org.duracloud.notification;
 
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceAsyncClient;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.duracloud.common.error.DuraCloudRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceAsyncClientBuilder;
 
 /**
  * @author Andrew Woods
@@ -32,9 +35,15 @@ public class AmazonNotificationFactory implements NotificationFactory {
 
     @Override
     public void initialize(String accessKey, String secretKey) {
-        emailService = new AmazonSimpleEmailServiceAsyncClient(new BasicAWSCredentials(
-            accessKey,
-            secretKey));
+		if (StringUtils.isNotBlank(accessKey)) {
+			log.debug("initialize email service with provided credentials");
+			emailService = AmazonSimpleEmailServiceAsyncClientBuilder.standard()
+					.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+					.build();
+		} else {
+			log.debug("initialize email service using the default AWS Default Credentials Chain provider");
+			emailService = AmazonSimpleEmailServiceAsyncClientBuilder.defaultClient();
+		}
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -383,6 +383,9 @@
         <version>2.19.1</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
+          <environmentVariables>
+            <AWS_REGION>us-east-1</AWS_REGION>
+          </environmentVariables>
           <systemProperties>
             <property>
               <name>unit.database.home</name>
@@ -415,6 +418,9 @@
             </goals>
             <configuration>
               <trimStackTrace>false</trimStackTrace>
+              <environmentVariables>
+                <AWS_REGION>us-east-1</AWS_REGION>
+              </environmentVariables>
               <systemProperties>
                 <property>
                   <name>unit.database.home</name>


### PR DESCRIPTION
The SES Email Service is created using the deprecated constructor that doesn't follow the region preference expressed on variable environment, etc. 
An additional issue is related to the forced use of explicit username/password without the possibility to rely on IAM roles

To be backward compatible I check if the credentials are provided in the configuration file and if so, they will be used. Otherwise, the default AWS Credentials chain is used that in turn mean the ability to use IAM role