### PR TITLE
Chunk manifests no longer fail when content id contains UTF-8 chars.

### DIFF
--- a/chunk/src/main/java/org/duracloud/chunk/stream/KnownLengthInputStream.java
+++ b/chunk/src/main/java/org/duracloud/chunk/stream/KnownLengthInputStream.java
@@ -20,8 +20,13 @@ public class KnownLengthInputStream extends ByteArrayInputStream {
     private int length;
 
     public KnownLengthInputStream(String content) {
-        super(content.getBytes());
-        this.length = content.length();
+        this(content.getBytes());
+    }
+    
+    public KnownLengthInputStream(byte[] bytes){
+        super(bytes);
+        this.length = bytes.length;
+        
     }
 
     public int getLength() {

--- a/chunk/src/test/java/org/duracloud/chunk/stream/KnownLengthInputStreamTest.java
+++ b/chunk/src/test/java/org/duracloud/chunk/stream/KnownLengthInputStreamTest.java
@@ -1,0 +1,44 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.chunk.stream;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * 
+ * @author dbernstein
+ *
+ */
+public class KnownLengthInputStreamTest {
+
+    @Test
+    public void testUTF8StreamLength() throws Exception {
+        testString("张大意");
+    }
+
+    @Test
+    public void testAsciStreamLength() throws Exception {
+        testString("abc");
+    }
+
+    protected void testString(String string)
+        throws IOException,
+            UnsupportedEncodingException {
+        int length = string.getBytes(StandardCharsets.UTF_8.name()).length;
+        try (KnownLengthInputStream is = new KnownLengthInputStream(string)) {
+            assertEquals(length, is.getLength());
+        }
+        ;
+    }
+
+}


### PR DESCRIPTION
Resovles:  https://jira.duraspace.org/browse/DURACLOUD-1147