### PR TITLE
Duracloud 840

### DIFF
--- a/synctool/src/test/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpointTest.java
+++ b/synctool/src/test/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpointTest.java
@@ -236,11 +236,17 @@ public class DuraStoreChunkSyncEndpointTest {
                     }
                 }).times(fileCount);
 
-        
+
+        EasyMock.expect(contentStore.contentExists(EasyMock.eq(spaceId),
+                                                   EasyMock.eq(contentId)))
+                .andReturn(false)
+                .times(threadCount);
+
         EasyMock.expect(contentStore.contentExists(EasyMock.eq(spaceId),
                                                    EasyMock.isA(String.class)))
                 .andReturn(false)
                 .times(chunkCount*threadCount);
+
 
         // setup file
         File contentFile  = IOUtil.writeStreamToFile(new ByteArrayInputStream(new byte[fileSize]));


### PR DESCRIPTION
Ensure that previously unchunked file is removed when overwritten by a chunked version of the identically named but differently checksummed file.

This fix can be tested using the following steps:

1. create a 2 MB file (fileA).
2. use the synctool.jar  to upload the file.
3. change the file by appending some text to it, e.g. echo "test" >> file
4. use the synctool again, but this time specify 1 MB chunks with the "-m 1m" parameters.
5. verify that there are three chunks (fileA.dura-chunk-0000-0002), and a fileA.dura-manifest 
6. verify that fileA has been deleted.