### PR TITLE
Ensures KnownLengthInputStream uses UTF-8 encoding for length calculation

### DIFF
--- a/chunk/src/main/java/org/duracloud/chunk/manifest/ChunksManifest.java
+++ b/chunk/src/main/java/org/duracloud/chunk/manifest/ChunksManifest.java
@@ -13,6 +13,7 @@ import org.duracloud.common.error.DuraCloudRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 
 /**
@@ -92,7 +93,11 @@ public class ChunksManifest extends ChunksManifestBean {
         String xml = ManifestDocumentBinding.createDocumentFrom(this);
         log.debug("Manifest body: '" + xml + "'");
 
-        return new KnownLengthInputStream(xml);
+        try {
+            return new KnownLengthInputStream(xml);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public String getMimetype() {

--- a/chunk/src/main/java/org/duracloud/chunk/stream/KnownLengthInputStream.java
+++ b/chunk/src/main/java/org/duracloud/chunk/stream/KnownLengthInputStream.java
@@ -8,6 +8,8 @@
 package org.duracloud.chunk.stream;
 
 import java.io.ByteArrayInputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * This wraps ByteArrayInputStream and adds a length field.
@@ -19,14 +21,13 @@ public class KnownLengthInputStream extends ByteArrayInputStream {
 
     private int length;
 
-    public KnownLengthInputStream(String content) {
-        this(content.getBytes());
+    public KnownLengthInputStream(String content) throws UnsupportedEncodingException {
+        this(content.getBytes(StandardCharsets.UTF_8.name()));
     }
-    
-    public KnownLengthInputStream(byte[] bytes){
+
+    public KnownLengthInputStream(byte[] bytes) {
         super(bytes);
         this.length = bytes.length;
-        
     }
 
     public int getLength() {

--- a/chunk/src/test/java/org/duracloud/chunk/stream/KnownLengthInputStreamTest.java
+++ b/chunk/src/test/java/org/duracloud/chunk/stream/KnownLengthInputStreamTest.java
@@ -32,13 +32,11 @@ public class KnownLengthInputStreamTest {
     }
 
     protected void testString(String string)
-        throws IOException,
-            UnsupportedEncodingException {
+        throws IOException, UnsupportedEncodingException {
         int length = string.getBytes(StandardCharsets.UTF_8.name()).length;
         try (KnownLengthInputStream is = new KnownLengthInputStream(string)) {
             assertEquals(length, is.getLength());
         }
-        ;
     }
 
 }


### PR DESCRIPTION
Resolves test failure on Windows due to default encoding