### PR TITLE
Properly handle UTF-8 characters in content properties

### DIFF
--- a/duradmin/src/main/webapp/jquery/dc/widget/ui.propertiesviewer.js
+++ b/duradmin/src/main/webapp/jquery/dc/widget/ui.propertiesviewer.js
@@ -11,14 +11,17 @@ $.widget("ui.propertiesviewer",
 				var that = this;
 				
 				//initialize table
-				var table =  $("table", this.element);
-				if(table.size() == 0){
-					table = $(document.createElement("table"));
-					this.getContent().prepend(table);	
+				var form = $("form", this.element);
+
+				if(form.children().length == 0){
+					form = $(document.createElement("form"));
+					var table = $(document.createElement("table"));
+					form.append(table);
+					this.getContent().prepend(form);
 					
 					if(!this.options.readOnly){
     					var addControlsRow = this._createControlsRow();
-    
+
     					var disableControls = function(){
     						$("input, button", that.element).attr("disabled", "disabled");
     						$(".dc-expando-status", addControlsRow).addClass("dc-busy");
@@ -36,7 +39,7 @@ $.widget("ui.propertiesviewer",
     					};
     					
     					var triggerAdd = function(){
-    						if(that._isValid()){
+    						if(that._isValid() && form.valid()){
         					    disableControls();
         						that.element
         						    .trigger(
@@ -51,7 +54,6 @@ $.widget("ui.propertiesviewer",
         						        }
         						    );
                             }
-    
     					};
     										  
     					//attach listeners
@@ -67,9 +69,22 @@ $.widget("ui.propertiesviewer",
 					this.getContent().prepend("<div id='empty-viewer-message'></div>");   
 
 				}
-				
-				this._initializeDataContainer();
-			}, 
+
+				form.validate({
+					rules : {
+						name : {
+							isusascii: true,
+						},
+						value : {
+							isusascii: true,
+						}
+					},
+					messages : {
+
+					}
+				});
+
+            },
 			
 			_setEmptyMessage: function(message){
 			  if(this.options.readOnly){
@@ -99,10 +114,7 @@ $.widget("ui.propertiesviewer",
 				
 				this._setEmptyMessage(data.length > 0 ? '' : this.options.emptyViewerMessage);
 			},
-			
-			_initializeDataContainer: function(){
-				
-			},
+
 			
 			_addSuccess: function(context){
 				var v = context._getValue();
@@ -151,13 +163,13 @@ $.widget("ui.propertiesviewer",
 				controls.append(
 					$(document.createElement("td"))
 						.addClass("name")
-						.html("<div><input type='text' placeholder='[name]' class='name-txt' size='15'/></div>")
+						.html("<div><input name='name' type='text' placeholder='[name]' class='name-txt' size='15'/></div>")
 				);
 
 				controls.append(
 						$(document.createElement("td"))
 							.addClass("value")
-							.html("<div><input type='text' placeholder='[value]' class='value-txt' size='20'/><input type='button' value='+'/><div class='dc-expando-status'></div></div>")
+							.html("<div><input name='value' type='text' placeholder='[value]' class='value-txt' size='20'/><input type='button' value='+'/><div class='dc-expando-status'></div></div>")
 					);
 				
 				return controls;

--- a/duradmin/src/main/webapp/jquery/dc/widget/ui.propertiesviewer.js
+++ b/duradmin/src/main/webapp/jquery/dc/widget/ui.propertiesviewer.js
@@ -163,7 +163,7 @@ $.widget("ui.propertiesviewer",
 				controls.append(
 					$(document.createElement("td"))
 						.addClass("name")
-						.html("<div><input name='name' type='text' placeholder='[name]' class='name-txt' size='15'/></div>")
+						.html("<div><input name='name' type='text' placeholder='[name]' class='name-txt' size='20'/></div>")
 				);
 
 				controls.append(

--- a/duradmin/src/main/webapp/jquery/dc/widget/ui.tagsviewer.js
+++ b/duradmin/src/main/webapp/jquery/dc/widget/ui.tagsviewer.js
@@ -28,7 +28,7 @@ $.widget("ui.tagsviewer",
 					controls.append(
 							$(document.createElement("td"))
 								.addClass("value")
-								.html("<input type='text' class='name-txt' placeholder='tag here'	 size='35'/><input type='button' value='+'/><div class='dc-expando-status'></div>")
+								.html("<input name='value' type='text' class='name-txt' placeholder='tag here'	 size='35'/><input type='button' value='+'/><div class='dc-expando-status'></div>")
 						);
 					
 					return controls;

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -56,6 +56,11 @@ $(function() {
     $.validator.addMethod("reserved", function(value, element) {
       return !(/^(init|stores|spaces|security|task|acl)$/.test(value));
     }, "A Space ID cannot be a reserved name");
+
+    $.validator.addMethod("isusascii", function(value, element) {
+      return /^[\x00-\x7F]*$/.test(value);
+    }, "Non US-ASCII chars are not allowed.");
+
     // end validator definitions
   })();
 

--- a/duradmin/src/main/webapp/style/base.css
+++ b/duradmin/src/main/webapp/style/base.css
@@ -869,6 +869,9 @@ span.label,
 	padding:5px;
  }
 
+.detail-pane label.error {
+	padding:0px;
+ }
 
  .health-check {
  	padding:5px;

--- a/durastore/src/main/java/org/duracloud/durastore/error/ResourcePropertiesInvalidException.java
+++ b/durastore/src/main/java/org/duracloud/durastore/error/ResourcePropertiesInvalidException.java
@@ -1,0 +1,23 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.durastore.error;
+
+/**
+ * An exception that indicates that one or more property names and or values are invalid.
+ *
+ * @author: Daniel Bernstein
+ * Date: Jun 15, 2018
+ */
+public class ResourcePropertiesInvalidException extends ResourceException {
+    public ResourcePropertiesInvalidException(String task,
+                                              String spaceId,
+                                              String contentId,
+                                              Exception ex) {
+        super(task, spaceId, contentId, ex);
+    }
+}

--- a/durastore/src/main/java/org/duracloud/durastore/rest/ContentRest.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/ContentRest.java
@@ -42,6 +42,7 @@ import org.duracloud.common.web.EncodeUtil;
 import org.duracloud.durastore.error.ResourceChecksumException;
 import org.duracloud.durastore.error.ResourceException;
 import org.duracloud.durastore.error.ResourceNotFoundException;
+import org.duracloud.durastore.error.ResourcePropertiesInvalidException;
 import org.duracloud.durastore.error.ResourceStateException;
 import org.duracloud.storage.domain.RetrievedContent;
 import org.duracloud.storage.error.InvalidIdException;
@@ -327,10 +328,10 @@ public class ContentRest extends BaseRest {
 
         } catch (ResourceNotFoundException e) {
             return responseNotFound(msg.toString(), e, NOT_FOUND);
-
+        } catch (ResourcePropertiesInvalidException e) {
+            return responseBad(e.getMessage(), BAD_REQUEST);
         } catch (ResourceStateException e) {
             return responseBad(msg.toString(), e, CONFLICT);
-
         } catch (ResourceException e) {
             return responseBad(msg.toString(), e, INTERNAL_SERVER_ERROR);
 
@@ -342,7 +343,7 @@ public class ContentRest extends BaseRest {
     private Response doUpdateContentProperties(String spaceID,
                                                String contentID,
                                                String storeID)
-        throws ResourceException {
+        throws ResourceException, ResourcePropertiesInvalidException {
         MultivaluedMap<String, String> rHeaders =
             headers.getRequestHeaders();
 
@@ -421,6 +422,9 @@ public class ContentRest extends BaseRest {
 
         } catch (InvalidIdException e) {
             return responseBad(msg.toString(), e, BAD_REQUEST);
+
+        } catch (ResourcePropertiesInvalidException e) {
+            return responseBad(msg.toString(), BAD_REQUEST);
 
         } catch (ResourceNotFoundException e) {
             return responseNotFound(msg.toString(), e, NOT_FOUND);

--- a/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreSyncEndpoint.java
+++ b/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreSyncEndpoint.java
@@ -10,6 +10,9 @@ package org.duracloud.sync.endpoint;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -322,7 +325,26 @@ public class DuraStoreSyncEndpoint implements SyncEndpoint {
     }
 
     protected Map<String, String> createProps(String absolutePath, String username) {
-        return StorageProviderUtil.createContentProperties(absolutePath, username);
+        Map<String, String> props = StorageProviderUtil.createContentProperties(absolutePath, username);
+        removePropsWithNonUSASCIINamesOrValues(props);
+        return props;
+    }
+
+    private void removePropsWithNonUSASCIINamesOrValues(Map<String, String> props) {
+        for (String key : new ArrayList<>(props.keySet())) {
+            if (!isAllUSASCII(key) || !isAllUSASCII(props.get(key))) {
+                props.remove(key);
+            }
+        }
+    }
+
+    private boolean isAllUSASCII(String value) {
+        if (value != null) {
+            CharsetEncoder encoder =
+                Charset.forName("US-ASCII").newEncoder();
+            return encoder.canEncode(value);
+        }
+        return true;
     }
 
     public Iterator<String> getFilesList() {


### PR DESCRIPTION
This PR addresses https://jira.duraspace.org/browse/DURACLOUD-752. 
There are changes to three areas: 

1. Duradmin
2. DuraStore
3. Synctool


Duradmin Test:

1. Create a content item.
2. Attempt to update  the properties or tags with non-us ascii characters.
3. Verify that there is an appropriate validation message and you are unable to submit the form.

DuraStore test
1. curl -v -X POST -H "x-dura-meta-test-1234: 无常" http://host:8080/durastore/yourspace/item.jpg?storeID=52 --data-binary "@item.jpg"

2. Verify that  a 400 BAD Request with description message is returned.

3. curl -v -X POST -H "x-dura-meta-test-1234: test" http://host:8080/durastore/yourspace/item.jpg?storeID=52 --data-binary "@item.jpg"

4. Verify that  a  201 is returned. 

5. curl -v -X POST -H "x-dura-meta-test-1234: 无常" http://host:8080/durastore/yourspace/item.jpg?storeID=52

6. Verify that a 400 with appropriate message is returned.

Synctool test:

1. Create a  directory directoryA with two files: item.jpg and 无常.jpg.
2. Use the synctool to sync that directory to a space.
3. Verify that both files are synced and that item.jpg contains content-file-path property while 无常.jpg does not.