### PR TITLE
Adds the "Content-Encoding: gzip" to the generated manifest properties.

### DIFF
--- a/common/src/test/java/org/duracloud/common/util/ChecksumUtilTest.java
+++ b/common/src/test/java/org/duracloud/common/util/ChecksumUtilTest.java
@@ -260,12 +260,14 @@ public class ChecksumUtilTest {
             new Thread(new Runnable() {
                 @Override
                 public void run() {
-                    if (util.generateChecksum(new ByteArrayInputStream(data)).equals(checksum)) {
-                        successes.incrementAndGet();
+                    try {
+                        if (util.generateChecksum(new ByteArrayInputStream(data)).equals(checksum)) {
+                            successes.incrementAndGet();
+                        }
+                    } catch (Exception e) {
+                        //do nothing
                     }
-
                     latch.countDown();
-
                 }
             }).start();
         }

--- a/duradmin/src/main/java/org/duracloud/duradmin/util/SpaceUtil.java
+++ b/duradmin/src/main/java/org/duracloud/duradmin/util/SpaceUtil.java
@@ -162,7 +162,7 @@ public class SpaceUtil {
         return properties;
     }
 
-    public static void streamContent(ContentStore store, HttpServletResponse response, String spaceId, String contentId)
+    public static void  streamContent(ContentStore store, HttpServletResponse response, String spaceId, String contentId)
         throws ContentStoreException, IOException {
         Content c = store.getContent(spaceId, contentId);
         Map<String, String> m = store.getContentProperties(spaceId, contentId);

--- a/durastore/src/test/java/org/duracloud/durastore/rest/ManifestRestTest.java
+++ b/durastore/src/test/java/org/duracloud/durastore/rest/ManifestRestTest.java
@@ -19,12 +19,14 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.duracloud.common.constant.Constants;
 import org.duracloud.common.constant.ManifestFormat;
@@ -35,7 +37,6 @@ import org.duracloud.storage.domain.StorageAccount;
 import org.duracloud.storage.domain.StorageProviderType;
 import org.duracloud.storage.provider.StorageProvider;
 import org.duracloud.storage.util.StorageProviderFactory;
-import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.easymock.IAnswer;
 import org.easymock.IExpectationSetters;
@@ -113,10 +114,13 @@ public class ManifestRestTest extends EasyMockSupport {
 
         expect(storageProviderFactory.getStorageProvider()).andReturn(provider);
 
+        Map<String, String> props = new HashMap<>();
+        props.put(HttpHeaders.CONTENT_ENCODING, "gzip");
+
         expect(provider.addContent(isA(String.class),
                                    isA(String.class),
                                    eq(ManifestFormat.TSV.getMimeType()),
-                                   EasyMock.<Map<String, String>>isNull(),
+                                   eq(props),
                                    anyLong(),
                                    isA(String.class),
                                    isA(InputStream.class)))

--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
@@ -467,11 +467,6 @@ public class S3StorageProvider extends StorageProviderBase {
         return map;
     }
 
-    @Override
-    public void setNewSpaceProperties(String spaceId, Map<String, String> spaceProperties) {
-        super.setNewSpaceProperties(spaceId, spaceProperties);
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/storageprovider/src/main/java/org/duracloud/storage/provider/StorageProviderBase.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/provider/StorageProviderBase.java
@@ -9,6 +9,7 @@ package org.duracloud.storage.provider;
 
 import static org.duracloud.storage.error.StorageException.NO_RETRY;
 
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -185,6 +186,18 @@ public abstract class StorageProviderBase implements StorageProvider {
 
         // save
         doSetSpaceProperties(spaceId, newProps);
+    }
+
+    @Override
+    public void setContentProperties(String spaceId, String contentId, Map<String, String> contentProperties) {
+
+    }
+
+    @Override
+    public String addContent(String spaceId, String contentId, String contentMimeType,
+                             Map<String, String> userProperties, long contentSize, String contentChecksum,
+                             InputStream content) {
+        return null;
     }
 
     /*

--- a/storageprovider/src/main/java/org/duracloud/storage/provider/StorageProviderBase.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/provider/StorageProviderBase.java
@@ -9,7 +9,6 @@ package org.duracloud.storage.provider;
 
 import static org.duracloud.storage.error.StorageException.NO_RETRY;
 
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -186,18 +185,6 @@ public abstract class StorageProviderBase implements StorageProvider {
 
         // save
         doSetSpaceProperties(spaceId, newProps);
-    }
-
-    @Override
-    public void setContentProperties(String spaceId, String contentId, Map<String, String> contentProperties) {
-
-    }
-
-    @Override
-    public String addContent(String spaceId, String contentId, String contentMimeType,
-                             Map<String, String> userProperties, long contentSize, String contentChecksum,
-                             InputStream content) {
-        return null;
     }
 
     /*

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
@@ -7,6 +7,7 @@
  */
 package org.duracloud.client;
 
+import static org.duracloud.client.HttpHeaders.CONTENT_ENCODING;
 import static org.duracloud.storage.provider.StorageProvider.PROPERTIES_SPACE_ACL;
 
 import java.io.ByteArrayInputStream;
@@ -285,7 +286,7 @@ public class ContentStoreImpl implements ContentStore {
             throw new UnauthorizedException(task, "listing", e);
         } catch (Exception e) {
             throw new ContentStoreException("Error attempting to get spaces " +
-                                            "due to: " + e.getMessage(), e);
+                                                "due to: " + e.getMessage(), e);
         }
     }
 
@@ -637,8 +638,8 @@ public class ContentStoreImpl implements ContentStore {
 
             if (contentChecksum != null && !returnedChecksum.equals(contentChecksum)) {
                 String message = MessageFormat.format("checksum returned from durastore ({0}) " +
-                                                      "does not match the checksum that was sent ({1}): " +
-                                                      "task={2}, spaceId={3}, contentId={4}",
+                                                          "does not match the checksum that was sent ({1}): " +
+                                                          "task={2}, spaceId={3}, contentId={4}",
                                                       returnedChecksum,
                                                       contentChecksum,
                                                       task,
@@ -1004,7 +1005,12 @@ public class ContentStoreImpl implements ContentStore {
         Map<String, String> headers = new HashMap<String, String>();
         if (properties != null) {
             for (String key : properties.keySet()) {
-                headers.put(HEADER_PREFIX + key, properties.get(key));
+                String value = properties.get(key);
+                if (key.equalsIgnoreCase(CONTENT_ENCODING)) {
+                    headers.put(CONTENT_ENCODING, value);
+                } else {
+                    headers.put(HEADER_PREFIX + key, value);
+                }
             }
         }
 
@@ -1037,12 +1043,14 @@ public class ContentStoreImpl implements ContentStore {
                 if (name.equals(HttpHeaders.CONTENT_TYPE)) {
                     headers.put(CONTENT_MIMETYPE, header.getValue());
                 } else if (name.equals(HttpHeaders.CONTENT_MD5) ||
-                           name.equals(HttpHeaders.ETAG)) {
+                    name.equals(HttpHeaders.ETAG)) {
                     headers.put(CONTENT_CHECKSUM, header.getValue());
                 } else if (name.equals(HttpHeaders.CONTENT_LENGTH)) {
                     headers.put(CONTENT_SIZE, header.getValue());
                 } else if (name.equals(HttpHeaders.LAST_MODIFIED)) {
                     headers.put(CONTENT_MODIFIED, header.getValue());
+                } else if (name.equals(CONTENT_ENCODING)) {
+                    headers.put(CONTENT_ENCODING, header.getValue());
                 }
             }
         }
@@ -1117,10 +1125,10 @@ public class ContentStoreImpl implements ContentStore {
             return SerializationUtil.deserializeList(reponseText);
         } catch (UnauthorizedException e) {
             throw new UnauthorizedException("Not authorized to get supported " +
-                                            "tasks", e);
+                                                "tasks", e);
         } catch (Exception e) {
             throw new ContentStoreException("Error getting supported tasks: " +
-                                            e.getMessage(), e);
+                                                e.getMessage(), e);
         }
     }
 
@@ -1162,12 +1170,12 @@ public class ContentStoreImpl implements ContentStore {
             throw new UnsupportedTaskException(taskName, e);
         } catch (UnauthorizedException e) {
             throw new UnauthorizedException("Not authorized to perform task: " +
-                                            taskName, e);
+                                                taskName, e);
         } catch (ContentStateException e) {
             throw e;
         } catch (Exception e) {
             throw new ContentStoreException("Error performing task (" +
-                                            taskName + "):  " + e.getMessage(), e);
+                                                taskName + "):  " + e.getMessage(), e);
         }
     }
 

--- a/storeclient/src/main/java/org/duracloud/client/HttpHeaders.java
+++ b/storeclient/src/main/java/org/duracloud/client/HttpHeaders.java
@@ -16,6 +16,7 @@ public interface HttpHeaders {
     public static final String CONTENT_MD5 = "Content-MD5";
     public static final String CONTENT_LENGTH = "Content-Length";
     public static final String CONTENT_TYPE = "Content-Type";
+    public static final String CONTENT_ENCODING = "Content-Encoding";
     public static final String ETAG = "ETag";
     public static final String LAST_MODIFIED = "Last-Modified";
     public static final String RANGE = org.apache.http.HttpHeaders.RANGE;

--- a/storeclient/src/test/java/org/duracloud/client/ContentStoreImplTest.java
+++ b/storeclient/src/test/java/org/duracloud/client/ContentStoreImplTest.java
@@ -280,13 +280,14 @@ public class ContentStoreImplTest {
         InputStream content = IOUtils.toInputStream("content");
         String checksum = "checksum";
         String mime = "text/plain";
-
+        String encoding = "encoding";
         Capture<Map<String, String>> headersCapture = new Capture<>();
         mockSuccessfulAddContent(headersCapture, checksum, mime, content);
-
+        Map<String,String> props = new HashMap<>();
+        props.put("Content-Encoding", encoding);
         contentStore.addContent(spaceId, contentId, content, 7,
-                                mime, checksum, null);
-        validAddContentHeadersCapture(checksum, mime, headersCapture);
+                                mime, checksum, props);
+        validAddContentHeadersCapture(checksum, mime, encoding, headersCapture);
     }
 
     @Test
@@ -294,12 +295,15 @@ public class ContentStoreImplTest {
         InputStream content = IOUtils.toInputStream("content");
         String checksum = "checksum";
         String mime = "text/plain";
+        String encoding = "encoding";
+        Map<String,String> props = new HashMap<>();
+        props.put("Content-Encoding", encoding);
 
         Capture<Map<String, String>> headersCapture = new Capture<>();
         mockSuccessfulAddContent(headersCapture, checksum, mime, content);
 
         contentStore.addContent(spaceId, contentId, content, 7,
-                                mime, null, null);
+                                mime, null, props);
     }
 
     @Test
@@ -308,6 +312,10 @@ public class ContentStoreImplTest {
         String checksum = "checksum";
         String outputChecksum = "badChecksum";
         String mime = "text/plain";
+        String encoding = "encoding";
+        Map<String,String> props = new HashMap<>();
+        props.put("Content-Encoding", encoding);
+
         InputStream content = IOUtils.toInputStream("content");
 
         mockSuccessfulAddContent(headersCapture,
@@ -317,13 +325,13 @@ public class ContentStoreImplTest {
 
         try {
             contentStore.addContent(spaceId, contentId, content, 7,
-                                    mime, checksum, null);
+                                    mime, checksum, props);
             fail("addContent call should have failed.");
         } catch (ContentStoreException e) {
             assertTrue("expected failure", true);
         }
 
-        validAddContentHeadersCapture(checksum, mime, headersCapture);
+        validAddContentHeadersCapture(checksum, mime, encoding, headersCapture);
     }
 
     protected void mockSuccessfulAddContent(Capture<Map<String, String>> headersCapture,
@@ -336,6 +344,7 @@ public class ContentStoreImplTest {
         EasyMock.expect(response.getStatusCode()).andReturn(201);
         EasyMock.expect(response.getResponseHeader(HttpHeaders.CONTENT_MD5))
                 .andReturn(new BasicHeader(HttpHeaders.CONTENT_MD5, outputChecksum));
+
         EasyMock.expect(restHelper.put(EasyMock.eq(fullURL),
                                        EasyMock.eq(content),
                                        EasyMock.eq(mime),
@@ -348,10 +357,12 @@ public class ContentStoreImplTest {
 
     protected void validAddContentHeadersCapture(String checksum,
                                                  String mime,
+                                                 String encoding,
                                                  Capture<Map<String, String>> headersCapture) {
         Map<String, String> headers = headersCapture.getValue();
         Assert.assertEquals(mime, headers.get("x-dura-meta-" + ContentStore.CONTENT_MIMETYPE));
         Assert.assertEquals(checksum, headers.get(HttpHeaders.CONTENT_MD5));
+        Assert.assertEquals(encoding, headers.get(HttpHeaders.CONTENT_ENCODING));
         Assert.assertNotNull(headers.get(Constants.CLIENT_VERSION_HEADER));
 
     }


### PR DESCRIPTION
Under the hood this commit is actually doing a bit more than simply adding Content-Encoding header to the generated manifest properties.

Content-Encoding support has been added to the StorageProvider, DuraStore, storeclient, and DurAdmin.  The ContentEncoding value is stored natively with the S3 api using the ObjectMetadata.contentEncoding property (rather than using generic object properties). When using the REST interface passing the Content-Encoding header on a POST will cause that header and value to appear on a subsequent GET.    Finally DuraAdmin allows users to add and remove the Content-Encoding property via the property editor.

Test: 

1.  Generate a manifest for an existing space and verify that the URI identified by the returned Location header contains the "Content-Encoding: gzip" header.
2.  Perform a POST against a new resource using the "Content-Encoding: gzip" header.  Perform a HEAD against the resource and verify that the Content-Encoding header is returned.
3.  Perform a POST against an existing resource using the "Content-Encoding: gzip" header.  Perform a HEAD against the resource and verify that the Content-Encoding header is returned.
4. Log into Duradmin and look at the resource and verify that the Content-Encoding header is displayed in the properties section.  Remove the property,  reload and verify that it is gone.  Add the property back in and verify that it is returned in the results of a HEAD request.

Resolves: https://jira.duraspace.org/browse/DURACLOUD-1119
