### PR TITLE
Ensures that a legible error message is produced by retrieval tool when:

### DIFF
--- a/retrievaltool/src/main/java/org/duracloud/retrieval/RetrievalTool.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/RetrievalTool.java
@@ -117,11 +117,11 @@ public class RetrievalTool {
                         specifiedIds.iterator());
                 } catch (FileNotFoundException fnfe) {
                     String error = "Error: file of content IDs specified using '-f' option does not exist.\n" +
-                        "Error Message: " + fnfe.getMessage();
+                                   "Error Message: " + fnfe.getMessage();
                     throw new DuraCloudRuntimeException(error, fnfe);
                 } catch (IOException ioe) {
                     String error = "Error: problem reading file of content IDs specified using '-f' option.\n" +
-                        "Error Message: " + ioe.getMessage();
+                                   "Error Message: " + ioe.getMessage();
                     throw new DuraCloudRuntimeException(error, ioe);
                 }
             } else {
@@ -179,7 +179,7 @@ public class RetrievalTool {
                 spaces = contentStore.getSpaces();
             } catch (ContentStoreException e) {
                 String errorMsg = "Unable to get spaces list due to error: " +
-                    e.getMessage();
+                                  e.getMessage();
                 throw new DuraCloudRuntimeException(errorMsg, e);
             }
         } else {
@@ -201,7 +201,7 @@ public class RetrievalTool {
     public void runRetrievalTool() {
         logger.info("Starting Retrieval Tool version " + version);
         logger.info("Running Retrieval Tool with configuration: " +
-                        retConfig.getPrintableConfig());
+                    retConfig.getPrintableConfig());
         System.out.print("\nStarting up the Retrieval Tool ...");
         System.out.println(retConfig.getPrintableConfig());
 
@@ -223,19 +223,19 @@ public class RetrievalTool {
                 startRetrievalManager(contentStore);
                 System.out.println("... Startup Complete");
                 System.out.println("The Retrieval Tool will exit when processing " +
-                                       "is complete. Status will be printed every " +
-                                       "10 minutes.\n");
+                                   "is complete. Status will be printed every " +
+                                   "10 minutes.\n");
                 waitForExit();
             }
 
         } catch (Exception ex) {
-            final  String message = ex.getMessage();
+            final String message = ex.getMessage();
             if (message != null && message.contains(" 401 ")) {
                 System.out.println("Your username/password combination is invalid.  " +
-                                       "Please check your credentials and try again. ");
+                                   "Please check your credentials and try again. ");
             } else {
                 System.out.println("The retrievaltool failed to start successfully due to the following error: \n" +
-                                       ex.getMessage());
+                                   ex.getMessage());
 
             }
             System.exit(-1);

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/RetrievalTool.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/RetrievalTool.java
@@ -117,11 +117,11 @@ public class RetrievalTool {
                         specifiedIds.iterator());
                 } catch (FileNotFoundException fnfe) {
                     String error = "Error: file of content IDs specified using '-f' option does not exist.\n" +
-                                   "Error Message: " + fnfe.getMessage();
+                        "Error Message: " + fnfe.getMessage();
                     throw new DuraCloudRuntimeException(error, fnfe);
                 } catch (IOException ioe) {
                     String error = "Error: problem reading file of content IDs specified using '-f' option.\n" +
-                                   "Error Message: " + ioe.getMessage();
+                        "Error Message: " + ioe.getMessage();
                     throw new DuraCloudRuntimeException(error, ioe);
                 }
             } else {
@@ -179,7 +179,7 @@ public class RetrievalTool {
                 spaces = contentStore.getSpaces();
             } catch (ContentStoreException e) {
                 String errorMsg = "Unable to get spaces list due to error: " +
-                                  e.getMessage();
+                    e.getMessage();
                 throw new DuraCloudRuntimeException(errorMsg, e);
             }
         } else {
@@ -201,30 +201,44 @@ public class RetrievalTool {
     public void runRetrievalTool() {
         logger.info("Starting Retrieval Tool version " + version);
         logger.info("Running Retrieval Tool with configuration: " +
-                    retConfig.getPrintableConfig());
+                        retConfig.getPrintableConfig());
         System.out.print("\nStarting up the Retrieval Tool ...");
         System.out.println(retConfig.getPrintableConfig());
 
         StoreClientUtil clientUtil = new StoreClientUtil();
-        ContentStore contentStore =
-            clientUtil.createContentStore(retConfig.getHost(),
-                                          retConfig.getPort(),
-                                          retConfig.getContext(),
-                                          retConfig.getUsername(),
-                                          retConfig.getPassword(),
-                                          retConfig.getStoreId());
 
-        executor = Executors.newFixedThreadPool(1);
-        if (retConfig.isListOnly()) {
-            startSpaceListManager(contentStore);
-        } else {
-            startRetrievalManager(contentStore);
-            System.out.println("... Startup Complete");
-            System.out.println("The Retrieval Tool will exit when processing " +
-                               "is complete. Status will be printed every " +
-                               "10 minutes.\n");
-            waitForExit();
+        try {
+            ContentStore contentStore =
+                clientUtil.createContentStore(retConfig.getHost(),
+                                              retConfig.getPort(),
+                                              retConfig.getContext(),
+                                              retConfig.getUsername(),
+                                              retConfig.getPassword(),
+                                              retConfig.getStoreId());
+
+            executor = Executors.newFixedThreadPool(1);
+            if (retConfig.isListOnly()) {
+                startSpaceListManager(contentStore);
+            } else {
+                startRetrievalManager(contentStore);
+                System.out.println("... Startup Complete");
+                System.out.println("The Retrieval Tool will exit when processing " +
+                                       "is complete. Status will be printed every " +
+                                       "10 minutes.\n");
+                waitForExit();
+            }
+
+        } catch (Exception ex) {
+            final  String message = ex.getMessage();
+            if (message != null && message.contains(" 401 ")) {
+                System.out.println("Your username/password combination is invalid.  " +
+                                       "Please check your credentials and try again. ");
+            } else {
+                System.out.println("The retrievaltool failed to start successfully due to the following error: \n" +
+                                       ex.getMessage());
+
+            }
+            System.exit(-1);
         }
     }
-
 }

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/util/StoreClientUtil.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/util/StoreClientUtil.java
@@ -38,7 +38,7 @@ public class StoreClientUtil {
             }
         } catch (ContentStoreException e) {
             throw new RuntimeException("Could not create connection to " +
-                                       "DuraStore due to " + e.getMessage(), e);
+                                           "DuraStore due to " + e.getMessage(), e);
         }
 
         return contentStore;

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/util/StoreClientUtil.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/util/StoreClientUtil.java
@@ -38,7 +38,7 @@ public class StoreClientUtil {
             }
         } catch (ContentStoreException e) {
             throw new RuntimeException("Could not create connection to " +
-                                           "DuraStore due to " + e.getMessage(), e);
+                                       "DuraStore due to " + e.getMessage(), e);
         }
 
         return contentStore;

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
@@ -128,6 +128,9 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
         throws ContentStoreException {
         StorageAccountManager acctManager = getStorageAccounts();
         StorageAccount acct = acctManager.getStorageAccount(storeID);
+        if (acct == null) {
+            throw new ContentStoreException("Content store with id = '" + storeID + "' not found.");
+        }
         return newContentStoreImpl(acct, maxRetries);
     }
 
@@ -196,12 +199,12 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
                     return storageAccountManager;
                 } else {
                     throw new StorageException(error +
-                                               "Response content was null");
+                                                   "Response content was null");
                 }
             } else {
                 error += "Response code was " + response.getStatusCode() +
-                         ", expected value was " + HttpStatus.SC_OK +
-                         ". Response Body: " + response.getResponseBody();
+                    ", expected value was " + HttpStatus.SC_OK +
+                    ". Response Body: " + response.getResponseBody();
                 throw new StorageException(error);
             }
         } catch (Exception e) {

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
@@ -199,12 +199,12 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
                     return storageAccountManager;
                 } else {
                     throw new StorageException(error +
-                                                   "Response content was null");
+                                               "Response content was null");
                 }
             } else {
                 error += "Response code was " + response.getStatusCode() +
-                    ", expected value was " + HttpStatus.SC_OK +
-                    ". Response Body: " + response.getResponseBody();
+                         ", expected value was " + HttpStatus.SC_OK +
+                         ". Response Body: " + response.getResponseBody();
                 throw new StorageException(error);
             }
         } catch (Exception e) {


### PR DESCRIPTION
1. username/password is invalid
2. host is invalid
3. storeId is invalid
4. other runtime exceptions occur

Resolves: https://jira.duraspace.org/browse/DURACLOUD-1143

To test: 

1.  build the source.
2. test bad username password:
` java -jar target/retrievaltool-4.5.0-SNAPSHOT-driver.jar -u <username>  -p <bad password>  -h <host> -s <spaceId>  -c <content dir>`
3. verify response is accurate and legible.
4.  test bad host: 
` java -jar target/retrievaltool-4.5.0-SNAPSHOT-driver.jar -u <username>  -p <password>  -h <bad host> -s <spaceId>  -c <content dir>`
5. verify response is accurate and legible.
6.  test bad storeId: 
` java -jar target/retrievaltool-4.5.0-SNAPSHOT-driver.jar -u <username>  -p <password>  -h <host> -s <spaceId>  -i <bad storeId> -c <content dir>`
8. verify response is accurate and legible.