### PR TITLE
Changes required to upgrade to apache 2.4.33 

### DIFF
--- a/resources/beanstalk/.ebextensions/elasticbeanstalk.conf
+++ b/resources/beanstalk/.ebextensions/elasticbeanstalk.conf
@@ -9,6 +9,8 @@ LoadModule rewrite_module modules/mod_rewrite.so
     Allow from all
   </Proxy>
 
+  ProxyTimeout 180 
+
   ProxyPass / http://localhost:8080/ retry=0
   ProxyPassReverse / http://localhost:8080/
   ProxyPreserveHost on

--- a/resources/beanstalk/.ebextensions/elasticbeanstalk.conf
+++ b/resources/beanstalk/.ebextensions/elasticbeanstalk.conf
@@ -1,12 +1,9 @@
-LoadModule rewrite_module modules/mod_rewrite.so
-
 <VirtualHost *:80>
   Timeout 300
   KeepAlive On
 
   <Proxy *>
-    Order deny,allow
-    Allow from all
+    Require all granted
   </Proxy>
 
   ProxyTimeout 180 


### PR DESCRIPTION
And adds proxy timeout (3 minutes) to prevent 502 and 504 errors for long running requests.