### PR TITLE
"Add Space" button no longer displayed upon login for user-level acco…

### DIFF
--- a/duradmin/src/main/webapp/style/base.css
+++ b/duradmin/src/main/webapp/style/base.css
@@ -1282,6 +1282,10 @@ button#enable-streaming {
 	margin-top:10px;
 }
 
+button.add-space-button {
+  display: none;
+}
+
 .dc-item-divider {
   background-color:#5b5b5b;
   padding:5px;


### PR DESCRIPTION
**"Add Space" button no longer displayed upon login for user-level accunt log-in**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-956

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Updates the UI so that the "Add Space" button is not displayed until the UI is fully initialized.  In the case of user-level accounts, the button will no longer appear and then shortly afterwards disappear.
# How should this be tested?
Log into DuraCloud with a user-level account.  Verify that the "Add Space" button does not appear at any point in the process of loading the initial view.

# Additional Notes:
I've uploaded the change to the Application Versions list in the test cluster in AWS which you can use to test.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
