### PR TITLE
Duracloud 1191: Adds support for range requests and automatic retrying of midstream failures from point of failure.

### DIFF
--- a/retrievaltool/src/main/java/org/duracloud/retrieval/util/StoreClientUtil.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/util/StoreClientUtil.java
@@ -19,6 +19,8 @@ import org.duracloud.error.ContentStoreException;
  */
 public class StoreClientUtil {
 
+    private static final int SOCKET_TIMEOUT_MS = 10 * 1000;
+
     public ContentStore createContentStore(String host,
                                            int port,
                                            String context,
@@ -26,7 +28,7 @@ public class StoreClientUtil {
                                            String password,
                                            String storeId) {
         ContentStoreManager storeManager =
-            new ContentStoreManagerImpl(host, String.valueOf(port), context);
+            new ContentStoreManagerImpl(host, String.valueOf(port), context, SOCKET_TIMEOUT_MS);
         storeManager.login(new Credential(username, password));
 
         ContentStore contentStore;

--- a/storeclient/src/main/java/org/duracloud/client/ContentStore.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStore.java
@@ -343,6 +343,23 @@ public interface ContentStore {
         throws ContentStoreException;
 
     /**
+     * Gets a byte range of a content item from a space.
+     * The startByte must be greater than or equal to 0 and less than the content length.
+     * The endByte can be null which indicates you would like all bytes beginning with the specified start byte.
+     * Otherwise the endByte must be less than the content length and greater than the startByte.
+     *
+     * @param spaceId   the identifier of the DuraCloud Space
+     * @param contentId the identifier of the content item
+     * @param startByte   the starting byte of the range.
+     * @param endByte  The end byte of the range.
+     * @return the content stream
+     * @throws NotFoundException     if the space or content does not exist
+     * @throws ContentStoreException if an error occurs
+     */
+    public Content getContent(String spaceId, String contentId, Long startByte, Long endByte)
+        throws ContentStoreException;
+
+    /**
      * Removes content from a space.
      *
      * @param spaceId   the identifier of the DuraCloud Space

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
@@ -852,7 +852,7 @@ public class ContentStoreImpl implements ContentStore {
         return content;
     }
 
-    HttpResponse doGetContent(String spaceId, String contentId, Long startByte, Long endByte)
+    protected HttpResponse doGetContent(String spaceId, String contentId, Long startByte, Long endByte)
         throws ContentStoreException {
         String task = "get content";
         String url = buildContentURL(spaceId, contentId);

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
@@ -810,13 +810,22 @@ public class ContentStoreImpl implements ContentStore {
      * {@inheritDoc}
      */
     @Override
-    public Content getContent(final String spaceId, final String contentId, final Long startByte, final Long endByte)
+    public Content getContent(String spaceId, String contentId, Long startByte, Long endByte)
         throws ContentStoreException {
-        return execute(new Retriable() {
-            @Override
-            public Content retry() throws ContentStoreException {
-                // The actual method being executed
-                return doGetContent(spaceId, contentId, startByte, endByte);
+
+        //validate args
+        if (startByte == null || startByte < 0) {
+            throw new IllegalArgumentException("startByte must be equal to or greater than zero.");
+        } else if (endByte != null && endByte <= startByte) {
+            throw new IllegalArgumentException("endByte must be null or greater than the startByte.");
+        }
+
+        return execute(() -> {
+            try {
+                final HttpResponse response = doGetContent(spaceId, contentId, startByte, endByte);
+                return toContent(response, spaceId, contentId, startByte, endByte);
+            } catch (IOException ex) {
+                throw new ContentStoreException(ex.getMessage(), ex);
             }
         });
     }
@@ -830,35 +839,35 @@ public class ContentStoreImpl implements ContentStore {
         return getContent(spaceId, contentId, 0l, null);
     }
 
-    private Content doGetContent(String spaceId, String contentId, Long startByte, Long endByte)
+    private Content toContent(HttpResponse response, String spaceId, String contentId, Long startByte, Long endByte)
+        throws IOException {
+        Content content = new Content();
+        content.setId(contentId);
+        content.setStream(
+            new PartialContentRetryInputStream(this, spaceId, contentId, response.getResponseStream(), startByte,
+                                               endByte));
+        content.setProperties(
+            mergeMaps(extractPropertiesFromHeaders(response),
+                      extractNonPropertiesHeaders(response)));
+        return content;
+    }
+
+    HttpResponse doGetContent(String spaceId, String contentId, Long startByte, Long endByte)
         throws ContentStoreException {
         String task = "get content";
         String url = buildContentURL(spaceId, contentId);
-
-        //vali
-        if (startByte == null || startByte < 0) {
-            throw new ContentStateException("startByte must be equal to or greater than zero.");
-        } else if (endByte != null && endByte <= startByte) {
-            throw new ContentStateException("endByte must be null or greater than the startByte.");
-        }
-
         try {
+            final boolean hasRange = !(startByte == 0l && endByte == null);
             final HttpResponse response;
-            if (startByte == 0l && endByte == null) {
+            if (!hasRange) {
                 response = restHelper.get(url);
             } else {
                 Map<String, String> headers = new HashMap<>();
                 headers.put("Range", "bytes=" + startByte + "-" + (endByte != null ? endByte : ""));
                 response = restHelper.get(url, headers);
             }
-            checkResponse(response, HttpStatus.SC_OK);
-            Content content = new Content();
-            content.setId(contentId);
-            content.setStream(response.getResponseStream());
-            content.setProperties(
-                mergeMaps(extractPropertiesFromHeaders(response),
-                          extractNonPropertiesHeaders(response)));
-            return content;
+            checkResponse(response, hasRange ? HttpStatus.SC_PARTIAL_CONTENT : HttpStatus.SC_OK);
+            return response;
         } catch (NotFoundException e) {
             throw new NotFoundException(task, spaceId, contentId, e);
         } catch (UnauthorizedException e) {

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
@@ -42,6 +42,8 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
 
     private RestHttpHelper restHelper;
 
+    private int socketTimeoutMs;
+
     /**
      * <p>Constructor for ContentStoreManagerImpl.</p>
      *
@@ -52,15 +54,21 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
         this(host, port, DEFAULT_CONTEXT);
     }
 
+    public ContentStoreManagerImpl(String host, String port, String context) {
+        this(host, port, context, -1);
+    }
+
     /**
      * <p>Constructor for ContentStoreManagerImpl.</p>
      *
      * @param host    the host name on which DuraStore can be accessed
      * @param port    the port on which DuraStore can be accessed
      * @param context the application context by which DuraStore can be accessed
+     * @param socketTimeoutMs The socket timeout in milliseconds. A value less than zero indicates no timeout.
      */
-    public ContentStoreManagerImpl(String host, String port, String context) {
+    public ContentStoreManagerImpl(String host, String port, String context, int socketTimeoutMs) {
         init(host, port, context);
+        this.socketTimeoutMs = socketTimeoutMs;
     }
 
     private void init(String host, String port, String context) {
@@ -169,7 +177,7 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
 
     public void login(Credential appCred) {
         log.debug("login: " + appCred.getUsername());
-        setRestHelper(new RestHttpHelper(appCred));
+        setRestHelper(new RestHttpHelper(appCred, socketTimeoutMs));
     }
 
     public void logout() {
@@ -249,7 +257,7 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
 
     protected RestHttpHelper getRestHelper() {
         if (null == restHelper) {
-            restHelper = new RestHttpHelper();
+            restHelper = new RestHttpHelper(this.socketTimeoutMs);
         }
         return restHelper;
     }

--- a/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
+++ b/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
@@ -70,7 +70,7 @@ class PartialContentRetryInputStream extends InputStream {
                 nextBytePos, spaceId, contentId, startByte, endByte);
             try {
                 //exponential backoff on retries
-                new Retrier(3, 1000, 2).execute(() -> {
+                new Retrier(5, 2000, 2).execute(() -> {
                     RestHttpHelper.HttpResponse response = contentStore.doGetContent(spaceId, contentId,
                                                                                      nextBytePos, endByte);
                     currentStream = response.getResponseStream();

--- a/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
+++ b/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
@@ -101,7 +101,7 @@ class PartialContentRetryInputStream extends InputStream {
             nextBytePos, spaceId, contentId, startByte, endByte);
         try {
             //exponential backoff on retries
-            new Retrier(5, 2000, 2).execute(() -> {
+            new Retrier(5, 4000, 3).execute(() -> {
                 RestHttpHelper.HttpResponse response = contentStore.doGetContent(spaceId, contentId,
                                                                                  nextBytePos, endByte);
                 currentStream = response.getResponseStream();
@@ -122,7 +122,12 @@ class PartialContentRetryInputStream extends InputStream {
     }
 
     @Override
-    public int available() throws IOException {
-        return this.currentStream.available();
+    public int available() {
+        return 0;
+    }
+
+    @Override
+    public void close() throws IOException {
+        this.currentStream.close();
     }
 }

--- a/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
+++ b/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
@@ -64,7 +64,7 @@ class PartialContentRetryInputStream extends InputStream {
             nextBytePos++;
             return b;
         } catch (IOException ex) {
-            log.warn(
+            log.info(
                 "Failed to read byte at position {} (space: {}, contentId: {}, startByte:{}, endByte: {}. " +
                 "Starting attempts to re-acquire stream from current position.",
                 nextBytePos, spaceId, contentId, startByte, endByte);
@@ -84,7 +84,7 @@ class PartialContentRetryInputStream extends InputStream {
                 //stream re-acquired, start reading again.
                 return read();
             } catch (Exception e) {
-                log.error(
+                log.warn(
                     "Exhausted max retries to re-acquire stream (space: {}, contentId: {}, nextBytePos:{}," +
                     " endByte: {}. ",
                     spaceId, contentId, nextBytePos, endByte, e);

--- a/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
+++ b/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
@@ -1,0 +1,95 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.duracloud.common.retry.Retrier;
+import org.duracloud.common.web.RestHttpHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class provides midstream retries of content stream should any interruption occur.
+ * If an IOException occurs will reading the underlying stream, range requests will be retried up to three times from
+ * each point of failure with exponential back off (the last attempt will  be tried 9 seconds after the penultimate).
+ * In other words, if a failure occurs the class will make three attempts to re-acquire the stream.  If it is
+ * successful, streaming will resume. If a second failure occurs, the three new attempts will be made before throwing an
+ * IOException.
+ *
+ * @author dbernstein
+ */
+class PartialContentRetryInputStream extends InputStream {
+    private static final Logger log = LoggerFactory.getLogger(PartialContentRetryInputStream.class);
+    private ContentStoreImpl contentStore;
+    private String spaceId;
+    private String contentId;
+    private InputStream currentStream;
+    private Long startByte;
+    private Long endByte;
+
+    private long nextBytePos;
+
+    /**
+     * Constructor
+     * @param contentStore The content store to use for retries
+     * @param spaceId The spaceId of the content item to retry
+     * @param contentId The content id of the item to retry
+     * @param currentStream The initial content stream
+     * @param startByte The starting byte offset of the specified stream
+     * @param endByte The last byte offset of the specified stream. If streaming to the end of the file, use null.
+     */
+    PartialContentRetryInputStream(ContentStoreImpl contentStore, String spaceId, String contentId,
+                                   InputStream currentStream, Long startByte, Long endByte) {
+        this.currentStream = currentStream;
+        this.spaceId = spaceId;
+        this.contentId = contentId;
+        this.startByte = startByte;
+        this.endByte = endByte;
+        this.contentStore = contentStore;
+        this.nextBytePos = startByte;
+    }
+
+    @Override
+    public int read() throws IOException {
+        try {
+            //read the next byte;
+            int b = this.currentStream.read();
+            nextBytePos++;
+            return b;
+        } catch (IOException ex) {
+            log.warn(
+                "Failed to read byte at position {} (space: {}, contentId: {}, startByte:{}, endByte: {}. " +
+                "Starting attempts to re-acquire stream from current position.",
+                nextBytePos, spaceId, contentId, startByte, endByte);
+            try {
+                //exponential backoff on retries
+                new Retrier(3, 1000, 2).execute(() -> {
+                    RestHttpHelper.HttpResponse response = contentStore.doGetContent(spaceId, contentId,
+                                                                                     nextBytePos, endByte);
+                    currentStream = response.getResponseStream();
+                    log.info(
+                        "Successfully  re-acquired stream (space: {}, contentId: {}, nextBytePos:{}," +
+                        " endByte: {}. ",
+                        spaceId, contentId, nextBytePos, endByte);
+                    return null;
+                });
+
+                //stream re-acquired, start reading again.
+                return read();
+            } catch (Exception e) {
+                log.error(
+                    "Exhausted max retries to re-acquire stream (space: {}, contentId: {}, nextBytePos:{}," +
+                    " endByte: {}. ",
+                    spaceId, contentId, nextBytePos, endByte, e);
+                throw new IOException(e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
+++ b/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
@@ -125,7 +125,7 @@ class PartialContentRetryInputStream extends InputStream {
     public int available() {
         try {
             return this.currentStream.available();
-        } catch(IOException ex){
+        } catch (IOException ex) {
             return 0;
         }
     }

--- a/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
+++ b/storeclient/src/main/java/org/duracloud/client/PartialContentRetryInputStream.java
@@ -123,7 +123,11 @@ class PartialContentRetryInputStream extends InputStream {
 
     @Override
     public int available() {
-        return 0;
+        try {
+            return this.currentStream.available();
+        } catch(IOException ex){
+            return 0;
+        }
     }
 
     @Override


### PR DESCRIPTION
**Adds support for range requests and automatic retrying of midstream failures from point of failure.**
* * *

**JIRA Ticket**:https://jira.duraspace.org/browse/DURACLOUD-1191

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
https://jira.duraspace.org/browse/DURACLOUD-1208

# What does this Pull Request do?
Adds support in the storeclient for performing range requests on content streams.
    Additionally now streams are automatically resumed from a point of failure in the case of
    an IOException encountered in midstream.
    
    All users of the storeclient (including the retrievaltool) will automatically benefit from
    this improvement as momentarily network failures will not trigger redownloading of an entire
    file (be it a chunk or otherwise).

# How should this be tested?
There are unit and integration tests covering the functionality. 

Additionally you could start retrieving a large file  (say 100 MB) and watch the file on disk as it approached completion.  Before it completes turn off wifi, and then turn it back on.  You should see the file continue to completion rather than starting over.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? Yes.
* Does this change add any new dependencies? No. 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? Yes

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
