### PR TITLE
Adds support for new management storage account property that allows …

### DIFF
--- a/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
+++ b/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
@@ -11,9 +11,10 @@
 						 [
 							<c:forEach var="storeOption" items="${contentStores}">
 							{
-							id: ${storeOption.storeId},
-							label: '<spring:message code="${fn:toLowerCase(storeOption.storageProviderType)}"/>',
-                            type: '${fn:toLowerCase(storeOption.storageProviderType)}'
+                            id: ${storeOption.storeId},
+                            label: '<spring:message code="${fn:toLowerCase(storeOption.storageProviderType)}"/>',
+                            type: '${fn:toLowerCase(storeOption.storageProviderType)}',
+                            writableByNonRoot: ${storeOption.writableByNonRoot}
 							},
 							</c:forEach>				
 						];

--- a/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
+++ b/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
@@ -14,7 +14,7 @@
                             id: ${storeOption.storeId},
                             label: '<spring:message code="${fn:toLowerCase(storeOption.storageProviderType)}"/>',
                             type: '${fn:toLowerCase(storeOption.storageProviderType)}',
-                            writableByNonRoot: ${storeOption.writableByNonRoot}
+                            writable: ${storeOption.writable}
 							},
 							</c:forEach>				
 						];

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -323,7 +323,7 @@ $(function() {
         !storeProviders.filter(function(sp){
                                     return sp.id == that._storeId;
                                 }).map(function(sp){
-                                    return sp.writableByNonRoot;
+                                    return sp.writable;
                                 })[0];
     },
 

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -318,7 +318,13 @@ $(function() {
     },
 
     _isReadOnlyStorageProvider : function() {
-      return !this._isPrimary() && !this._isRoot();
+      var that = this;
+      return !this._isRoot() && !this._isPrimary() &&
+        !storeProviders.filter(function(sp){
+                                    return sp.id == that._storeId;
+                                }).map(function(sp){
+                                    return sp.writableByNonRoot;
+                                })[0];
     },
 
     _isReadOnly : function(/* space or contentItem obj */obj) {

--- a/storageprovider/src/main/java/org/duracloud/storage/domain/StorageAccount.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/domain/StorageAccount.java
@@ -40,7 +40,7 @@ public interface StorageAccount {
         BRIDGE_PASS,
         BRIDGE_MEMBER_ID,
         //GENERAL
-        WRITABLE_BY_NON_ROOT(false);
+        WRITABLE(false);
 
         private boolean hidden;
 

--- a/storageprovider/src/main/java/org/duracloud/storage/domain/StorageAccount.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/domain/StorageAccount.java
@@ -38,7 +38,30 @@ public interface StorageAccount {
         BRIDGE_PORT,
         BRIDGE_USER,
         BRIDGE_PASS,
-        BRIDGE_MEMBER_ID;
+        BRIDGE_MEMBER_ID,
+        //GENERAL
+        WRITABLE_BY_NON_ROOT(false);
+
+        private boolean hidden;
+
+        OPTS() {
+            this(true);
+        }
+
+        OPTS(final boolean hidden) {
+            this.hidden = hidden;
+        }
+
+        /**
+         * Returns true if this option should not be exposed in serializations
+         * unless explicitly requested. See
+         * {@link org.duracloud.storage.xml.StorageAccountProviderBinding#getElementFrom(StorageAccount, boolean, boolean)}
+         *
+         * @return
+         */
+        public boolean isHidden() {
+            return this.hidden;
+        }
     }
 
     public String getId();

--- a/storageprovider/src/main/java/org/duracloud/storage/xml/StorageAccountProviderBinding.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/xml/StorageAccountProviderBinding.java
@@ -32,10 +32,11 @@ public interface StorageAccountProviderBinding {
      *
      * @param acct               from whence xml will be built
      * @param includeCredentials flag indicating inclusion of credentials in xml
+     * @param includeHiddenOptions flag indicating inclusion of hidden options in xml
      * @return xml element
      * @throws Exception
      */
     public Element getElementFrom(StorageAccount acct,
                                   boolean includeCredentials,
-                                  boolean includeOptions);
+                                  boolean includeHiddenOptions);
 }

--- a/storageprovider/src/main/java/org/duracloud/storage/xml/impl/StorageAccountProviderSimpleBindingImpl.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/xml/impl/StorageAccountProviderSimpleBindingImpl.java
@@ -164,18 +164,17 @@ public class StorageAccountProviderSimpleBindingImpl implements StorageAccountPr
             storageAcct.addContent(storageProviderCredential);
         }
 
-        if (includeOptions) {
-            Map<String, String> options = acct.getOptions();
-            if (null != options && !options.isEmpty()) {
-                Element storageProviderOptions = new Element(
-                    "storageProviderOptions");
-                storageAcct.addContent(storageProviderOptions);
+        Map<String, String> options = acct.getOptions();
+        if (null != options && !options.isEmpty()) {
+            Element storageProviderOptions = new Element(
+                "storageProviderOptions");
+            storageAcct.addContent(storageProviderOptions);
 
-                for (String key : options.keySet()) {
+            for (String key : options.keySet()) {
+                if (includeOptions || !StorageAccount.OPTS.valueOf(key).isHidden()) {
                     Element option = new Element("option");
                     option.setAttribute("name", key);
                     option.setAttribute("value", options.get(key));
-
                     storageProviderOptions.addContent(option);
                 }
             }

--- a/storageprovider/src/main/java/org/duracloud/storage/xml/impl/StorageAccountProviderSimpleBindingImpl.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/xml/impl/StorageAccountProviderSimpleBindingImpl.java
@@ -129,7 +129,7 @@ public class StorageAccountProviderSimpleBindingImpl implements StorageAccountPr
     @Override
     public Element getElementFrom(StorageAccount acct,
                                   boolean includeCredentials,
-                                  boolean includeOptions) {
+                                  boolean includeHiddenOptions) {
 
         Element storageAcct = new Element("storageAcct");
         storageAcct.setAttribute("ownerId", "0");
@@ -171,7 +171,7 @@ public class StorageAccountProviderSimpleBindingImpl implements StorageAccountPr
             storageAcct.addContent(storageProviderOptions);
 
             for (String key : options.keySet()) {
-                if (includeOptions || !StorageAccount.OPTS.valueOf(key).isHidden()) {
+                if (includeHiddenOptions || !StorageAccount.OPTS.valueOf(key).isHidden()) {
                     Element option = new Element("option");
                     option.setAttribute("name", key);
                     option.setAttribute("value", options.get(key));

--- a/storageprovider/src/test/java/org/duracloud/storage/xml/impl/StorageAccountProviderSimpleBindingImplTest.java
+++ b/storageprovider/src/test/java/org/duracloud/storage/xml/impl/StorageAccountProviderSimpleBindingImplTest.java
@@ -166,7 +166,7 @@ public class StorageAccountProviderSimpleBindingImplTest {
         StorageProviderType type = StorageProviderType.AMAZON_S3;
         String hiddenOptionName = StorageAccount.OPTS.CF_KEY_ID.name();
         String hiddenOptionValue = "option-value";
-        String openOptionName = StorageAccount.OPTS.WRITABLE_BY_NON_ROOT.name();
+        String openOptionName = StorageAccount.OPTS.WRITABLE.name();
         String openOptionValue = "option-value";
 
         StorageAccount account =

--- a/storeclient/src/main/java/org/duracloud/client/ContentStore.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStore.java
@@ -111,7 +111,7 @@ public interface ContentStore {
      * Indicates whether or not the content store is writable by non root users.
      * @return
      */
-    public boolean isWritableByNonRoot();
+    public boolean isWritable();
 
     /**
      * Gets the storage provider type

--- a/storeclient/src/main/java/org/duracloud/client/ContentStore.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStore.java
@@ -108,6 +108,12 @@ public interface ContentStore {
     public String getStoreId();
 
     /**
+     * Indicates whether or not the content store is writable by non root users.
+     * @return
+     */
+    public boolean isWritableByNonRoot();
+
+    /**
      * Gets the storage provider type
      * {@link org.duracloud.storage.domain.StorageProviderType}
      */

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
@@ -72,6 +72,8 @@ public class ContentStoreImpl implements ContentStore {
 
     private StorageProviderType type = null;
 
+    private boolean writableByNonRoot;
+
     private String baseURL = null;
 
     private RestHttpHelper restHelper;
@@ -91,18 +93,23 @@ public class ContentStoreImpl implements ContentStore {
      * Creates a ContentStore. This ContentStore uses the default number of
      * retries when a failure occurs (3).
      *
-     * @param baseURL a {@link java.lang.String} object.
-     * @param type    a {@link org.duracloud.storage.domain.StorageProviderType} object.
-     * @param storeId a {@link java.lang.String} object.
+     * @param baseURL           a {@link java.lang.String} object.
+     * @param type              a {@link org.duracloud.storage.domain.StorageProviderType} object.
+     * @param storeId           a {@link java.lang.String} object.
+     * @param writableByNonRoot flag that indicates whether the content store is writable by non-users (value can be
+     *                          toggled in the Management Console)
+     * @param restHelper        a {@link org.duracloud.common.web.RestHttpHelper} object
      */
     public ContentStoreImpl(String baseURL,
                             StorageProviderType type,
                             String storeId,
+                            boolean writableByNonRoot,
                             RestHttpHelper restHelper) {
         this.baseURL = baseURL;
         this.type = type;
         this.storeId = storeId;
         this.restHelper = restHelper;
+        this.writableByNonRoot = writableByNonRoot;
 
         this.retryExceptionHandler = new ExceptionHandler() {
             @Override
@@ -126,9 +133,10 @@ public class ContentStoreImpl implements ContentStore {
     public ContentStoreImpl(String baseURL,
                             StorageProviderType type,
                             String storeId,
+                            boolean writableByNonRootUser,
                             RestHttpHelper restHelper,
                             int maxRetries) {
-        this(baseURL, type, storeId, restHelper);
+        this(baseURL, type, storeId, writableByNonRootUser, restHelper);
         if (maxRetries >= 0) {
             this.maxRetries = maxRetries;
         }
@@ -152,6 +160,14 @@ public class ContentStoreImpl implements ContentStore {
     @Override
     public String getStoreId() {
         return storeId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isWritableByNonRoot() {
+        return writableByNonRoot;
     }
 
     /**

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
@@ -72,7 +72,7 @@ public class ContentStoreImpl implements ContentStore {
 
     private StorageProviderType type = null;
 
-    private boolean writableByNonRoot;
+    private boolean writable;
 
     private String baseURL = null;
 
@@ -96,20 +96,20 @@ public class ContentStoreImpl implements ContentStore {
      * @param baseURL           a {@link java.lang.String} object.
      * @param type              a {@link org.duracloud.storage.domain.StorageProviderType} object.
      * @param storeId           a {@link java.lang.String} object.
-     * @param writableByNonRoot flag that indicates whether the content store is writable by non-users (value can be
-     *                          toggled in the Management Console)
+     * @param writable          flag that indicates whether the content store is writable by non-root users (value
+     *                          can be toggled in the Management Console)
      * @param restHelper        a {@link org.duracloud.common.web.RestHttpHelper} object
      */
     public ContentStoreImpl(String baseURL,
                             StorageProviderType type,
                             String storeId,
-                            boolean writableByNonRoot,
+                            boolean writable,
                             RestHttpHelper restHelper) {
         this.baseURL = baseURL;
         this.type = type;
         this.storeId = storeId;
         this.restHelper = restHelper;
-        this.writableByNonRoot = writableByNonRoot;
+        this.writable = writable;
 
         this.retryExceptionHandler = new ExceptionHandler() {
             @Override
@@ -133,10 +133,10 @@ public class ContentStoreImpl implements ContentStore {
     public ContentStoreImpl(String baseURL,
                             StorageProviderType type,
                             String storeId,
-                            boolean writableByNonRootUser,
+                            boolean writable,
                             RestHttpHelper restHelper,
                             int maxRetries) {
-        this(baseURL, type, storeId, writableByNonRootUser, restHelper);
+        this(baseURL, type, storeId, writable, restHelper);
         if (maxRetries >= 0) {
             this.maxRetries = maxRetries;
         }
@@ -166,8 +166,8 @@ public class ContentStoreImpl implements ContentStore {
      * {@inheritDoc}
      */
     @Override
-    public boolean isWritableByNonRoot() {
-        return writableByNonRoot;
+    public boolean isWritable() {
+        return writable;
     }
 
     /**

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
@@ -216,7 +216,12 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
         return new ContentStoreImpl(baseURL,
                                     acct.getType(),
                                     acct.getId(),
+                                    isWritableByNonRoot(acct),
                                     getRestHelper());
+    }
+
+    protected boolean isWritableByNonRoot(StorageAccount acct) {
+        return Boolean.valueOf(acct.getOptions().get(StorageAccount.OPTS.WRITABLE_BY_NON_ROOT.name()));
     }
 
     protected ContentStore newContentStoreImpl(StorageAccount acct,
@@ -224,6 +229,7 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
         return new ContentStoreImpl(baseURL,
                                     acct.getType(),
                                     acct.getId(),
+                                    isWritableByNonRoot(acct),
                                     getRestHelper(),
                                     maxRetries);
     }
@@ -232,6 +238,7 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
         return new ContentStoreImpl(baseURL,
                                     StorageProviderType.UNKNOWN,
                                     null,
+                                    false,
                                     getRestHelper());
     }
 
@@ -239,6 +246,7 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
         return new ContentStoreImpl(baseURL,
                                     StorageProviderType.UNKNOWN,
                                     null,
+                                    false,
                                     getRestHelper(),
                                     maxRetries);
     }

--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreManagerImpl.java
@@ -216,12 +216,12 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
         return new ContentStoreImpl(baseURL,
                                     acct.getType(),
                                     acct.getId(),
-                                    isWritableByNonRoot(acct),
+                                    isWritable(acct),
                                     getRestHelper());
     }
 
-    protected boolean isWritableByNonRoot(StorageAccount acct) {
-        return Boolean.valueOf(acct.getOptions().get(StorageAccount.OPTS.WRITABLE_BY_NON_ROOT.name()));
+    protected boolean isWritable(StorageAccount acct) {
+        return Boolean.valueOf(acct.getOptions().get(StorageAccount.OPTS.WRITABLE.name()));
     }
 
     protected ContentStore newContentStoreImpl(StorageAccount acct,
@@ -229,7 +229,7 @@ public class ContentStoreManagerImpl implements ContentStoreManager, Securable {
         return new ContentStoreImpl(baseURL,
                                     acct.getType(),
                                     acct.getId(),
-                                    isWritableByNonRoot(acct),
+                                    isWritable(acct),
                                     getRestHelper(),
                                     maxRetries);
     }

--- a/storeclient/src/main/java/org/duracloud/client/impl/CachingContentStoreImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/impl/CachingContentStoreImpl.java
@@ -35,8 +35,9 @@ public class CachingContentStoreImpl extends ContentStoreImpl {
     public CachingContentStoreImpl(String baseURL,
                                    StorageProviderType type,
                                    String storeId,
+                                   Boolean writableByNonRoot,
                                    RestHttpHelper restHelper) {
-        super(baseURL, type, storeId, restHelper);
+        super(baseURL, type, storeId, writableByNonRoot, restHelper);
     }
 
     @Override

--- a/storeclient/src/main/java/org/duracloud/client/impl/CachingContentStoreImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/impl/CachingContentStoreImpl.java
@@ -35,9 +35,9 @@ public class CachingContentStoreImpl extends ContentStoreImpl {
     public CachingContentStoreImpl(String baseURL,
                                    StorageProviderType type,
                                    String storeId,
-                                   Boolean writableByNonRoot,
+                                   Boolean writable,
                                    RestHttpHelper restHelper) {
-        super(baseURL, type, storeId, writableByNonRoot, restHelper);
+        super(baseURL, type, storeId, writable, restHelper);
     }
 
     @Override

--- a/storeclient/src/main/java/org/duracloud/client/impl/CachingContentStoreManagerImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/impl/CachingContentStoreManagerImpl.java
@@ -66,6 +66,7 @@ public class CachingContentStoreManagerImpl extends ContentStoreManagerImpl {
         return new CachingContentStoreImpl(getBaseURL(),
                                            acct.getType(),
                                            acct.getId(),
+                                           isWritableByNonRoot(acct),
                                            getRestHelper());
     }
 

--- a/storeclient/src/main/java/org/duracloud/client/impl/CachingContentStoreManagerImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/impl/CachingContentStoreManagerImpl.java
@@ -66,7 +66,7 @@ public class CachingContentStoreManagerImpl extends ContentStoreManagerImpl {
         return new CachingContentStoreImpl(getBaseURL(),
                                            acct.getType(),
                                            acct.getId(),
-                                           isWritableByNonRoot(acct),
+                                           isWritable(acct),
                                            getRestHelper());
     }
 

--- a/storeclient/src/test/java/org/duracloud/client/ContentIteratorTest.java
+++ b/storeclient/src/test/java/org/duracloud/client/ContentIteratorTest.java
@@ -46,7 +46,7 @@ public class ContentIteratorTest {
         private List<String> contentItems;
 
         public MockStore(long numItems) {
-            super(null, null, null, null);
+            super(null, null, null, false, null);
             this.contentItems = new ArrayList<String>();
             for (int i = 0; i < numItems; ++i) {
                 this.contentItems.add("test" + i);

--- a/storeclient/src/test/java/org/duracloud/client/ContentStoreImplTest.java
+++ b/storeclient/src/test/java/org/duracloud/client/ContentStoreImplTest.java
@@ -76,7 +76,7 @@ public class ContentStoreImplTest {
         response = EasyMock.createMock("HttpResponse",
                                        RestHttpHelper.HttpResponse.class);
 
-        contentStore = new ContentStoreImpl(baseURL, type, storeId, restHelper);
+        contentStore = new ContentStoreImpl(baseURL, type, storeId, false, restHelper);
     }
 
     @After
@@ -128,7 +128,7 @@ public class ContentStoreImplTest {
     }
 
     private Integer doWork(int expectedFailures) throws ContentStoreException {
-        ContentStoreImpl fakeStore = new ContentStoreImpl(null, null, null, null);
+        ContentStoreImpl fakeStore = new ContentStoreImpl(null, null, null, false,  null);
         return fakeStore.execute(new TestRetriable(expectedFailures));
     }
 
@@ -522,7 +522,7 @@ public class ContentStoreImplTest {
     public void testCopyContentErrorWithDefaultStore() throws Exception {
         int retries = 2;
         contentStore =
-            new ContentStoreImpl(baseURL, type, storeId, restHelper, retries);
+            new ContentStoreImpl(baseURL, type, storeId, false, restHelper, retries);
         doTestCopyContentError(storeId, retries);
     }
 
@@ -530,7 +530,7 @@ public class ContentStoreImplTest {
     public void testCopyContentErrorWithAlternateStore() throws Exception {
         int retries = 4;
         contentStore =
-            new ContentStoreImpl(baseURL, type, storeId, restHelper, retries);
+            new ContentStoreImpl(baseURL, type, storeId, false, restHelper, retries);
         doTestCopyContentError("1", retries);
     }
 

--- a/storeclient/src/test/java/org/duracloud/client/impl/CachingContentStoreImplTest.java
+++ b/storeclient/src/test/java/org/duracloud/client/impl/CachingContentStoreImplTest.java
@@ -31,6 +31,7 @@ public class CachingContentStoreImplTest {
         contentStore = new CachingContentStoreImpl("http://example.org",
                                                    StorageProviderType.AMAZON_S3,
                                                    "store-id",
+                                                   false,
                                                    createMockRestHelper());
     }
 


### PR DESCRIPTION
**Adds support for new storage account property that allows admins to control whether or not non-root users can modify secondary storage providers **
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1201

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
In order to tests this you will need to build and deploy https://github.com/duracloud/management-console/pull/19 after building  and deploying this PR.
# What does this Pull Request do?
This PR ensures that the WRITABLE_BY_NON_ROOT property of the storage provider gets propagated to Duradmin which in turn uses it to allow users to edit the secondary storage providers when this property is enabled. 

# How to test.
1. add an "Admin" and "User" to the account account
2. go into the MC, ensure that the secondary provider's writable flag is unchecked.
3. Log into the duracloud with the admin user. 
4. Browse to the secondary storage provider.
5. Ensure that it is not writable (ie you can't add, change, or delete spaces)
6. Log in as root and verify that it is writable.
7. Log in as "User" and verify that it is not writable.
8. In the MC check the writable flag in the storage providers configuration screen
9. Log in as root and verify that the secondary store is writable.
10. Log in as admin and verify that the secondary store is writable.
11. Log in as user and verify that the secondary store is writable.  If no spaces are showing up in the list, you must grant your "User" normal acl permissions in order to view/change/delete existing spaces.

# Additional Notes:
Do we want to enforce not allowing users to modify the storage provider via durastore when the property is set to false?  Currently it only prevents users of the UI from making changes.  The policy is not enforced at the REST api level.

Example:
* Does this change require documentation to be updated? Probably
* Does this change add any new dependencies?  No
* Could this change impact execution of existing code? Possibly.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
