### PR TITLE
Use AmazonS3ClientBuilder

### DIFF
--- a/auditor/src/main/java/org/duracloud/audit/reader/impl/AuditLogReaderImpl.java
+++ b/auditor/src/main/java/org/duracloud/audit/reader/impl/AuditLogReaderImpl.java
@@ -18,7 +18,8 @@ import java.util.Iterator;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.apache.commons.io.IOUtils;
 import org.duracloud.audit.AuditLogUtil;
 import org.duracloud.audit.reader.AuditLogReader;
@@ -122,7 +123,7 @@ public class AuditLogReaderImpl implements AuditLogReader {
 
     protected StorageProvider getStorageProvider() {
         AWSCredentials creds = new DefaultAWSCredentialsProviderChain().getCredentials();
-        AmazonS3Client s3client = new AmazonS3Client();
+        AmazonS3 s3client = AmazonS3ClientBuilder.standard().build();
         return new S3StorageProvider(s3client, creds.getAWSAccessKeyId(), null);
     }
 

--- a/common-rest/src/main/java/org/duracloud/common/rest/spring/XmlWebApplicationContext.java
+++ b/common-rest/src/main/java/org/duracloud/common/rest/spring/XmlWebApplicationContext.java
@@ -7,7 +7,8 @@
  */
 package org.duracloud.common.rest.spring;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
@@ -26,7 +27,7 @@ public class XmlWebApplicationContext
     @Override
     protected Resource getResourceByPath(String path) {
         if (path.startsWith("s3://")) {
-            AmazonS3Client client = new AmazonS3Client();
+            AmazonS3 client = AmazonS3ClientBuilder.standard().build();
             AmazonS3URI s3Uri = new AmazonS3URI(path);
             S3Object s3Obj = client.getObject(new GetObjectRequest(s3Uri.getBucket(), s3Uri.getKey()));
             s3Obj.getObjectContent();

--- a/durastore/src/main/java/org/duracloud/durastore/util/TaskProviderFactoryImpl.java
+++ b/durastore/src/main/java/org/duracloud/durastore/util/TaskProviderFactoryImpl.java
@@ -10,7 +10,7 @@ package org.duracloud.durastore.util;
 import java.util.Map;
 
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.glacierstorage.GlacierStorageProvider;
 import org.duracloud.glaciertask.GlacierTaskProvider;
 import org.duracloud.mill.manifest.ManifestStore;
@@ -81,7 +81,7 @@ public class TaskProviderFactoryImpl extends ProviderFactoryBase
         if (type.equals(StorageProviderType.AMAZON_S3)) {
             S3StorageProvider unwrappedS3Provider =
                 new S3StorageProvider(username, password, account.getOptions());
-            AmazonS3Client s3Client =
+            AmazonS3 s3Client =
                 S3ProviderUtil.getAmazonS3Client(username, password, account.getOptions());
             AmazonCloudFrontClient cfClient =
                 S3ProviderUtil.getAmazonCloudFrontClient(username, password);
@@ -107,7 +107,7 @@ public class TaskProviderFactoryImpl extends ProviderFactoryBase
         } else if (type.equals(StorageProviderType.AMAZON_GLACIER)) {
             GlacierStorageProvider unwrappedGlacierProvider =
                 new GlacierStorageProvider(username, password, account.getOptions());
-            AmazonS3Client s3Client =
+            AmazonS3 s3Client =
                 S3ProviderUtil.getAmazonS3Client(username, password, account.getOptions());
             taskProvider = new GlacierTaskProvider(storageProvider,
                                                    unwrappedGlacierProvider,
@@ -123,7 +123,7 @@ public class TaskProviderFactoryImpl extends ProviderFactoryBase
                 unwrappedSnapshotProvider =
                     new ChronopolisStorageProvider(username, password);
             }
-            AmazonS3Client s3Client =
+            AmazonS3 s3Client =
                 S3ProviderUtil.getAmazonS3Client(username, password, account.getOptions());
 
             Map<String, String> opts = account.getOptions();

--- a/glacierstorageprovider/src/main/java/org/duracloud/glacierstorage/GlacierStorageProvider.java
+++ b/glacierstorageprovider/src/main/java/org/duracloud/glacierstorage/GlacierStorageProvider.java
@@ -9,7 +9,7 @@ package org.duracloud.glacierstorage;
 
 import java.util.Map;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.StorageClass;
 import org.duracloud.s3storage.S3StorageProvider;
@@ -42,7 +42,7 @@ public class GlacierStorageProvider extends S3StorageProvider {
         super(accessKey, secretKey);
     }
 
-    public GlacierStorageProvider(AmazonS3Client s3Client, String accessKey) {
+    public GlacierStorageProvider(AmazonS3 s3Client, String accessKey) {
         super(s3Client, accessKey, null);
     }
 

--- a/glacierstorageprovider/src/main/java/org/duracloud/glaciertask/GlacierTaskProvider.java
+++ b/glacierstorageprovider/src/main/java/org/duracloud/glaciertask/GlacierTaskProvider.java
@@ -7,7 +7,7 @@
  */
 package org.duracloud.glaciertask;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.glacierstorage.GlacierStorageProvider;
 import org.duracloud.storage.provider.StorageProvider;
 import org.duracloud.storage.provider.TaskProviderBase;
@@ -21,7 +21,7 @@ public class GlacierTaskProvider extends TaskProviderBase {
 
     public GlacierTaskProvider(StorageProvider glacierProvider,
                                GlacierStorageProvider unwrappedGlacierProvider,
-                               AmazonS3Client s3Client,
+                               AmazonS3 s3Client,
                                String storeId) {
         super(storeId);
         log = LoggerFactory.getLogger(GlacierTaskProvider.class);

--- a/glacierstorageprovider/src/main/java/org/duracloud/glaciertask/RestoreContentTaskRunner.java
+++ b/glacierstorageprovider/src/main/java/org/duracloud/glaciertask/RestoreContentTaskRunner.java
@@ -7,7 +7,7 @@
  */
 package org.duracloud.glaciertask;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import org.duracloud.glacierstorage.GlacierStorageProvider;
 import org.duracloud.storage.error.StorageStateException;
@@ -28,11 +28,11 @@ public class RestoreContentTaskRunner implements TaskRunner {
 
     private StorageProvider glacierProvider;
     private GlacierStorageProvider unwrappedGlacierProvider;
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
 
     public RestoreContentTaskRunner(StorageProvider glacierProvider,
                                     GlacierStorageProvider unwrappedGlacierProvider,
-                                    AmazonS3Client s3Client) {
+                                    AmazonS3 s3Client) {
         this.glacierProvider = glacierProvider;
         this.unwrappedGlacierProvider = unwrappedGlacierProvider;
         this.s3Client = s3Client;

--- a/glacierstorageprovider/src/test/java/org/duracloud/glacierstorage/GlacierStorageProviderTest.java
+++ b/glacierstorageprovider/src/test/java/org/duracloud/glacierstorage/GlacierStorageProviderTest.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.Bucket;
@@ -42,7 +42,7 @@ import org.junit.Test;
  */
 public class GlacierStorageProviderTest {
 
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
 
     // Must be 20 char alphanum (and lowercase, to match bucket naming pattern)
     private static final String accessKey = "abcdefghijklmnopqrst";
@@ -55,7 +55,7 @@ public class GlacierStorageProviderTest {
 
     @Before
     public void setup() {
-        s3Client = EasyMock.createMock("AmazonS3Client", AmazonS3Client.class);
+        s3Client = EasyMock.createMock("AmazonS3", AmazonS3.class);
         glacierEx = new AmazonS3Exception("err msg");
         glacierEx.setErrorCode(GlacierStorageProvider.INVALID_OBJECT_STATE);
     }

--- a/glacierstorageprovider/src/test/java/org/duracloud/glaciertask/RestoreContentTaskRunnerTest.java
+++ b/glacierstorageprovider/src/test/java/org/duracloud/glaciertask/RestoreContentTaskRunnerTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import org.duracloud.glacierstorage.GlacierStorageProvider;
 import org.duracloud.storage.error.StorageStateException;
@@ -29,7 +29,7 @@ import org.junit.Test;
  */
 public class RestoreContentTaskRunnerTest {
 
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
     private StorageProvider glacierProvider;
     private GlacierStorageProvider unwrappedGlacierProvider;
     private RestoreContentTaskRunner taskRunner;
@@ -39,7 +39,7 @@ public class RestoreContentTaskRunnerTest {
 
     @Before
     public void setup() {
-        s3Client = EasyMock.createMock("AmazonS3Client", AmazonS3Client.class);
+        s3Client = EasyMock.createMock("AmazonS3", AmazonS3.class);
         glacierProvider = EasyMock.createMock("StorageProvider",
                                               StorageProvider.class);
         unwrappedGlacierProvider =

--- a/integration/src/test/java/org/duracloud/integration/durastore/storage/probe/ProbedRestS3Client.java
+++ b/integration/src/test/java/org/duracloud/integration/durastore/storage/probe/ProbedRestS3Client.java
@@ -15,8 +15,11 @@ import java.util.List;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AbstractAmazonS3;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.Bucket;
 import com.amazonaws.services.s3.model.BucketLoggingConfiguration;
@@ -58,7 +61,7 @@ import org.duracloud.common.util.metrics.MetricsTable;
  *
  * @author Bill Branan
  */
-public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed {
+public class ProbedRestS3Client extends AbstractAmazonS3 implements AmazonS3, MetricsProbed {
 
     private static final long serialVersionUID = 1L;
 
@@ -66,8 +69,12 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
 
     protected Metric metric = null;
 
-    public ProbedRestS3Client(AWSCredentials credentials) throws AmazonServiceException {
-        super(credentials);
+    protected AmazonS3 s3Client;
+
+    public ProbedRestS3Client(BasicAWSCredentials credentials) throws AmazonServiceException {
+        this.s3Client = AmazonS3ClientBuilder.standard()
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .build();
     }
 
     protected void startMetric(String methodName) {
@@ -104,7 +111,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         throws AmazonClientException {
         startMetric("listNextBatchOfVersions");
         VersionListing result =
-            super.listNextBatchOfVersions(previousVersionListing);
+            s3Client.listNextBatchOfVersions(previousVersionListing);
         stopMetric("listNextBatchOfVersions");
         return result;
     }
@@ -113,7 +120,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public VersionListing listVersions(String bucketName, String prefix)
         throws AmazonClientException {
         startMetric("listVersions");
-        VersionListing result = super.listVersions(bucketName, prefix);
+        VersionListing result = s3Client.listVersions(bucketName, prefix);
         stopMetric("listVersions");
         return result;
     }
@@ -127,7 +134,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
                                        Integer maxKeys)
         throws AmazonClientException {
         startMetric("listVersions");
-        VersionListing result = super.listVersions(bucketName,
+        VersionListing result = s3Client.listVersions(bucketName,
                                                    prefix,
                                                    keyMarker,
                                                    versionIdMarker,
@@ -141,7 +148,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public VersionListing listVersions(ListVersionsRequest listVersionsRequest)
         throws AmazonClientException {
         startMetric("listVersions");
-        VersionListing result = super.listVersions(listVersionsRequest);
+        VersionListing result = s3Client.listVersions(listVersionsRequest);
         stopMetric("listVersions");
         return result;
     }
@@ -150,7 +157,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public ObjectListing listObjects(String bucketName)
         throws AmazonClientException {
         startMetric("listObjects");
-        ObjectListing result = super.listObjects(bucketName);
+        ObjectListing result = s3Client.listObjects(bucketName);
         stopMetric("listObjects");
         return result;
     }
@@ -159,7 +166,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public ObjectListing listObjects(String bucketName, String prefix)
         throws AmazonClientException {
         startMetric("listObjects");
-        ObjectListing result = super.listObjects(bucketName, prefix);
+        ObjectListing result = s3Client.listObjects(bucketName, prefix);
         stopMetric("listObjects");
         return result;
     }
@@ -168,7 +175,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public ObjectListing listObjects(ListObjectsRequest listObjectsRequest)
         throws AmazonClientException {
         startMetric("listObjects");
-        ObjectListing result = super.listObjects(listObjectsRequest);
+        ObjectListing result = s3Client.listObjects(listObjectsRequest);
         stopMetric("listObjects");
         return result;
     }
@@ -179,7 +186,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         throws AmazonClientException {
         startMetric("listNextBatchOfObjects");
         ObjectListing result =
-            super.listNextBatchOfObjects(previousObjectListing);
+            s3Client.listNextBatchOfObjects(previousObjectListing);
         stopMetric("listNextBatchOfObjects");
         return result;
     }
@@ -188,7 +195,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public Owner getS3AccountOwner()
         throws AmazonClientException {
         startMetric("getS3AccountOwner");
-        Owner result = super.getS3AccountOwner();
+        Owner result = s3Client.getS3AccountOwner();
         stopMetric("getS3AccountOwner");
         return result;
     }
@@ -197,7 +204,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public List<Bucket> listBuckets(ListBucketsRequest listBucketsRequest)
         throws AmazonClientException {
         startMetric("listBuckets");
-        List<Bucket> result = super.listBuckets(listBucketsRequest);
+        List<Bucket> result = listBuckets(listBucketsRequest);
         stopMetric("listBuckets");
         return result;
     }
@@ -206,7 +213,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public List<Bucket> listBuckets()
         throws AmazonClientException {
         startMetric("listBuckets");
-        List<Bucket> result = super.listBuckets();
+        List<Bucket> result = s3Client.listBuckets();
         stopMetric("listBuckets");
         return result;
     }
@@ -215,7 +222,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public String getBucketLocation(String bucketName)
         throws AmazonClientException {
         startMetric("getBucketLocation");
-        String result = super.getBucketLocation(bucketName);
+        String result = s3Client.getBucketLocation(bucketName);
         stopMetric("getBucketLocation");
         return result;
     }
@@ -224,7 +231,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public Bucket createBucket(String bucketName)
         throws AmazonClientException {
         startMetric("createBucket");
-        Bucket result = super.createBucket(bucketName);
+        Bucket result = s3Client.createBucket(bucketName);
         stopMetric("createBucket");
         return result;
     }
@@ -233,7 +240,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public Bucket createBucket(String bucketName, Region region)
         throws AmazonClientException {
         startMetric("createBucket");
-        Bucket result = super.createBucket(bucketName, region);
+        Bucket result = s3Client.createBucket(bucketName, region);
         stopMetric("createBucket");
         return result;
     }
@@ -242,7 +249,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public Bucket createBucket(String bucketName, String region)
         throws AmazonClientException {
         startMetric("createBucket");
-        Bucket result = super.createBucket(bucketName, region);
+        Bucket result = s3Client.createBucket(bucketName, region);
         stopMetric("createBucket");
         return result;
     }
@@ -251,7 +258,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public Bucket createBucket(CreateBucketRequest createBucketRequest)
         throws AmazonClientException {
         startMetric("createBucket");
-        Bucket result = super.createBucket(createBucketRequest);
+        Bucket result = s3Client.createBucket(createBucketRequest);
         stopMetric("createBucket");
         return result;
     }
@@ -260,7 +267,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public AccessControlList getObjectAcl(String bucketName, String key)
         throws AmazonClientException {
         startMetric("getObjectAcl");
-        AccessControlList result = super.getObjectAcl(bucketName, key);
+        AccessControlList result = s3Client.getObjectAcl(bucketName, key);
         stopMetric("getObjectAcl");
         return result;
     }
@@ -271,7 +278,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         throws AmazonClientException {
         startMetric("getObjectAcl");
         AccessControlList result =
-            super.getObjectAcl(bucketName, key, versionId);
+            s3Client.getObjectAcl(bucketName, key, versionId);
         stopMetric("getObjectAcl");
         return result;
     }
@@ -281,7 +288,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
                              AccessControlList acl)
         throws AmazonClientException {
         startMetric("setObjectAcl");
-        super.setObjectAcl(bucketName, key, acl);
+        s3Client.setObjectAcl(bucketName, key, acl);
         stopMetric("setObjectAcl");
     }
 
@@ -290,7 +297,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
                              CannedAccessControlList acl)
         throws AmazonClientException {
         startMetric("setObjectAcl");
-        super.setObjectAcl(bucketName, key, acl);
+        s3Client.setObjectAcl(bucketName, key, acl);
         stopMetric("setObjectAcl");
     }
 
@@ -299,7 +306,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
                              AccessControlList acl)
         throws AmazonClientException {
         startMetric("setObjectAcl");
-        super.setObjectAcl(bucketName, key, versionId, acl);
+        s3Client.setObjectAcl(bucketName, key, versionId, acl);
         stopMetric("setObjectAcl");
     }
 
@@ -308,7 +315,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
                              CannedAccessControlList acl)
         throws AmazonClientException {
         startMetric("setObjectAcl");
-        super.setObjectAcl(bucketName, key, versionId, acl);
+        s3Client.setObjectAcl(bucketName, key, versionId, acl);
         stopMetric("setObjectAcl");
     }
 
@@ -316,7 +323,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public AccessControlList getBucketAcl(String bucketName)
         throws AmazonClientException {
         startMetric("getBucketAcl");
-        AccessControlList result = super.getBucketAcl(bucketName);
+        AccessControlList result = s3Client.getBucketAcl(bucketName);
         stopMetric("getBucketAcl");
         return result;
     }
@@ -325,7 +332,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void setBucketAcl(String bucketName, AccessControlList acl)
         throws AmazonClientException {
         startMetric("setBucketAcl");
-        super.setBucketAcl(bucketName, acl);
+        s3Client.setBucketAcl(bucketName, acl);
         stopMetric("setBucketAcl");
     }
 
@@ -333,7 +340,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void setBucketAcl(String bucketName, CannedAccessControlList acl)
         throws AmazonClientException {
         startMetric("setBucketAcl");
-        super.setBucketAcl(bucketName, acl);
+        s3Client.setBucketAcl(bucketName, acl);
         stopMetric("setBucketAcl");
     }
 
@@ -341,7 +348,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public ObjectMetadata getObjectMetadata(String bucketName, String key)
         throws AmazonClientException {
         startMetric("getObjectMetadata");
-        ObjectMetadata result = super.getObjectMetadata(bucketName, key);
+        ObjectMetadata result = s3Client.getObjectMetadata(bucketName, key);
         stopMetric("getObjectMetadata");
         return result;
     }
@@ -352,7 +359,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         throws AmazonClientException {
         startMetric("getObjectMetadata");
         ObjectMetadata result =
-            super.getObjectMetadata(getObjectMetadataRequest);
+            s3Client.getObjectMetadata(getObjectMetadataRequest);
         stopMetric("getObjectMetadata");
         return result;
     }
@@ -361,7 +368,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public S3Object getObject(String bucketName, String key)
         throws AmazonClientException {
         startMetric("getObject");
-        S3Object result = super.getObject(bucketName, key);
+        S3Object result = s3Client.getObject(bucketName, key);
         stopMetric("getObject");
         return result;
     }
@@ -370,7 +377,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public boolean doesBucketExist(String bucketName)
         throws AmazonClientException {
         startMetric("doesBucketExist");
-        boolean result = super.doesBucketExist(bucketName);
+        boolean result = s3Client.doesBucketExist(bucketName);
         stopMetric("doesBucketExist");
         return result;
     }
@@ -380,7 +387,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
                                          StorageClass newStorageClass)
         throws AmazonClientException {
         startMetric("changeObjectStorageClass");
-        super.changeObjectStorageClass(bucketName, key, newStorageClass);
+        s3Client.changeObjectStorageClass(bucketName, key, newStorageClass);
         stopMetric("changeObjectStorageClass");
     }
 
@@ -388,7 +395,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public S3Object getObject(GetObjectRequest getObjectRequest)
         throws AmazonClientException {
         startMetric("getObject");
-        S3Object result = super.getObject(getObjectRequest);
+        S3Object result = s3Client.getObject(getObjectRequest);
         stopMetric("getObject");
         return result;
     }
@@ -399,7 +406,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         throws AmazonClientException {
         startMetric("getObject");
         ObjectMetadata result =
-            super.getObject(getObjectRequest, destinationFile);
+            s3Client.getObject(getObjectRequest, destinationFile);
         stopMetric("getObject");
         return result;
     }
@@ -408,7 +415,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void deleteBucket(String bucketName)
         throws AmazonClientException {
         startMetric("deleteBucket");
-        super.deleteBucket(bucketName);
+        s3Client.deleteBucket(bucketName);
         stopMetric("deleteBucket");
     }
 
@@ -416,7 +423,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void deleteBucket(DeleteBucketRequest deleteBucketRequest)
         throws AmazonClientException {
         startMetric("deleteBucket");
-        super.deleteBucket(deleteBucketRequest);
+        s3Client.deleteBucket(deleteBucketRequest);
         stopMetric("deleteBucket");
     }
 
@@ -424,7 +431,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public PutObjectResult putObject(String bucketName, String key, File file)
         throws AmazonClientException {
         startMetric("putObject");
-        PutObjectResult result = super.putObject(bucketName, key, file);
+        PutObjectResult result = s3Client.putObject(bucketName, key, file);
         stopMetric("putObject");
         return result;
     }
@@ -435,7 +442,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         throws AmazonClientException {
         startMetric("putObject");
         PutObjectResult result =
-            super.putObject(bucketName, key, input, metadata);
+            s3Client.putObject(bucketName, key, input, metadata);
         stopMetric("putObject");
         return result;
     }
@@ -444,7 +451,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public PutObjectResult putObject(PutObjectRequest putObjectRequest)
         throws AmazonClientException {
         startMetric("putObject");
-        PutObjectResult result = super.putObject(putObjectRequest);
+        PutObjectResult result = s3Client.putObject(putObjectRequest);
         stopMetric("putObject");
         return result;
     }
@@ -456,7 +463,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
                                        String destinationKey)
         throws AmazonClientException {
         startMetric("copyObject");
-        CopyObjectResult result = super.copyObject(sourceBucketName,
+        CopyObjectResult result = s3Client.copyObject(sourceBucketName,
                                                    sourceKey,
                                                    destinationBucketName,
                                                    destinationKey);
@@ -468,7 +475,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public CopyObjectResult copyObject(CopyObjectRequest copyObjectRequest)
         throws AmazonClientException {
         startMetric("copyObject");
-        CopyObjectResult result = super.copyObject(copyObjectRequest);
+        CopyObjectResult result = s3Client.copyObject(copyObjectRequest);
         stopMetric("copyObject");
         return result;
     }
@@ -477,7 +484,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void deleteObject(String bucketName, String key)
         throws AmazonClientException {
         startMetric("deleteObject");
-        super.deleteObject(bucketName, key);
+        s3Client.deleteObject(bucketName, key);
         stopMetric("deleteObject");
     }
 
@@ -485,7 +492,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void deleteObject(DeleteObjectRequest deleteObjectRequest)
         throws AmazonClientException {
         startMetric("deleteObject");
-        super.deleteObject(deleteObjectRequest);
+        s3Client.deleteObject(deleteObjectRequest);
         stopMetric("deleteObject");
     }
 
@@ -493,7 +500,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void deleteVersion(String bucketName, String key, String versionId)
         throws AmazonClientException {
         startMetric("deleteVersion");
-        super.deleteVersion(bucketName, key, versionId);
+        s3Client.deleteVersion(bucketName, key, versionId);
         stopMetric("deleteVersion");
     }
 
@@ -501,7 +508,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void deleteVersion(DeleteVersionRequest deleteVersionRequest)
         throws AmazonClientException {
         startMetric("deleteVersion");
-        super.deleteVersion(deleteVersionRequest);
+        s3Client.deleteVersion(deleteVersionRequest);
         stopMetric("deleteVersion");
     }
 
@@ -510,7 +517,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         SetBucketVersioningConfigurationRequest setBucketVersioningConfigurationRequest)
         throws AmazonClientException {
         startMetric("setBucketVersioningConfiguration");
-        super.setBucketVersioningConfiguration(setBucketVersioningConfigurationRequest);
+        s3Client.setBucketVersioningConfiguration(setBucketVersioningConfigurationRequest);
         stopMetric("setBucketVersioningConfiguration");
     }
 
@@ -520,7 +527,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         throws AmazonClientException {
         startMetric("getBucketVersioningConfiguration");
         BucketVersioningConfiguration result =
-            super.getBucketVersioningConfiguration(bucketName);
+            s3Client.getBucketVersioningConfiguration(bucketName);
         stopMetric("getBucketVersioningConfiguration");
         return result;
     }
@@ -530,7 +537,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
                                                    BucketNotificationConfiguration bucketNotificationConfiguration)
         throws AmazonClientException {
         startMetric("setBucketNotificationConfiguration");
-        super.setBucketNotificationConfiguration(bucketName,
+        s3Client.setBucketNotificationConfiguration(bucketName,
                                                  bucketNotificationConfiguration);
         stopMetric("setBucketNotificationConfiguration");
     }
@@ -540,7 +547,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         throws AmazonClientException {
         startMetric("getBucketNotificationConfiguration");
         BucketNotificationConfiguration result =
-            super.getBucketNotificationConfiguration(bucketName);
+            s3Client.getBucketNotificationConfiguration(bucketName);
         stopMetric("getBucketNotificationConfiguration");
         return result;
     }
@@ -550,7 +557,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         throws AmazonClientException {
         startMetric("getBucketLoggingConfiguration");
         BucketLoggingConfiguration result =
-            super.getBucketLoggingConfiguration(bucketName);
+            s3Client.getBucketLoggingConfiguration(bucketName);
         stopMetric("getBucketLoggingConfiguration");
         return result;
     }
@@ -560,7 +567,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         SetBucketLoggingConfigurationRequest setBucketLoggingConfigurationRequest)
         throws AmazonClientException {
         startMetric("setBucketLoggingConfiguration");
-        super.setBucketLoggingConfiguration(
+        s3Client.setBucketLoggingConfiguration(
             setBucketLoggingConfigurationRequest);
         stopMetric("setBucketLoggingConfiguration");
     }
@@ -569,7 +576,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public BucketPolicy getBucketPolicy(String bucketName)
         throws AmazonClientException {
         startMetric("getBucketPolicy");
-        BucketPolicy result = super.getBucketPolicy(bucketName);
+        BucketPolicy result = s3Client.getBucketPolicy(bucketName);
         stopMetric("getBucketPolicy");
         return result;
     }
@@ -578,7 +585,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void setBucketPolicy(String bucketName, String policyText)
         throws AmazonClientException {
         startMetric("setBucketPolicy");
-        super.setBucketPolicy(bucketName, policyText);
+        s3Client.setBucketPolicy(bucketName, policyText);
         stopMetric("setBucketPolicy");
     }
 
@@ -586,7 +593,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public void deleteBucketPolicy(String bucketName)
         throws AmazonClientException {
         startMetric("deleteBucketPolicy");
-        super.deleteBucketPolicy(bucketName);
+        s3Client.deleteBucketPolicy(bucketName);
         stopMetric("deleteBucketPolicy");
     }
 
@@ -594,7 +601,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
     public URL generatePresignedUrl(String bucketName, String key, Date expiration)
         throws AmazonClientException {
         startMetric("generatePresignedUrl");
-        URL result = super.generatePresignedUrl(bucketName, key, expiration);
+        URL result = s3Client.generatePresignedUrl(bucketName, key, expiration);
         stopMetric("generatePresignedUrl");
         return result;
     }
@@ -605,7 +612,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
                                     com.amazonaws.HttpMethod method)
         throws AmazonClientException {
         startMetric("generatePresignedUrl");
-        URL result = super.generatePresignedUrl(bucketName, key, expiration, method);
+        URL result = s3Client.generatePresignedUrl(bucketName, key, expiration, method);
         stopMetric("generatePresignedUrl");
         return result;
     }
@@ -615,7 +622,7 @@ public class ProbedRestS3Client extends AmazonS3Client implements MetricsProbed 
         GeneratePresignedUrlRequest generatePresignedUrlRequest)
         throws AmazonClientException {
         startMetric("generatePresignedUrl");
-        URL result = super.generatePresignedUrl(generatePresignedUrlRequest);
+        URL result = s3Client.generatePresignedUrl(generatePresignedUrlRequest);
         stopMetric("generatePresignedUrl");
         return result;
     }

--- a/integration/src/test/java/org/duracloud/integration/durastore/storage/probe/ProbedS3StorageProvider.java
+++ b/integration/src/test/java/org/duracloud/integration/durastore/storage/probe/ProbedS3StorageProvider.java
@@ -8,7 +8,6 @@
 package org.duracloud.integration.durastore.storage.probe;
 
 import com.amazonaws.AmazonServiceException;
-import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
 import org.duracloud.common.util.metrics.MetricsProbed;
 import org.duracloud.s3storage.S3StorageProvider;
@@ -27,21 +26,18 @@ public class ProbedS3StorageProvider extends ProbedStorageProvider {
 
     public ProbedS3StorageProvider(String accessKey, String secretKey)
         throws StorageException {
-        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
-
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
         try {
             probedCore = new ProbedRestS3Client(awsCredentials);
         } catch (AmazonServiceException e) {
             String err = "Could not create connection to S3 due to error: " + e.getMessage();
             throw new StorageException(err, e);
         }
-
-        storageProvider = new S3StorageProvider(probedCore, accessKey, null);
+        storageProvider = new S3StorageProvider(probedCore.s3Client, accessKey, null);
     }
 
     @Override
     protected MetricsProbed getProbedCore() {
         return probedCore;
     }
-
 }

--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
@@ -14,10 +14,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Region;
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
@@ -32,17 +34,17 @@ import org.springframework.core.io.Resource;
  */
 public class S3ProviderUtil {
 
-    private static Map<String, AmazonS3Client> s3Clients = new HashMap<>();
+    private static Map<String, AmazonS3> s3Clients = new HashMap<>();
     private static Map<String, AmazonCloudFrontClient> cloudFrontClients = new HashMap<>();
 
     private S3ProviderUtil() {
         // Ensures no instances are made of this class, as there are only static members.
     }
 
-    public static AmazonS3Client getAmazonS3Client(String accessKey,
-                                                   String secretKey,
-                                                   Map<String, String> options) {
-        AmazonS3Client client = s3Clients.get(key(accessKey, secretKey));
+    public static AmazonS3 getAmazonS3Client(String accessKey,
+                                             String secretKey,
+                                             Map<String, String> options) {
+        AmazonS3 client = s3Clients.get(key(accessKey, secretKey));
         if (null == client) {
             Region region = null;
             if (options != null && options.get(StorageAccount.OPTS.AWS_REGION.name()) != null) {
@@ -59,17 +61,21 @@ public class S3ProviderUtil {
         return accessKey + secretKey;
     }
 
-    private static AmazonS3Client newS3Client(String accessKey,
-                                              String secretKey,
-                                              com.amazonaws.regions.Region region) {
-        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey,
-                                                                     secretKey);
+    private static AmazonS3 newS3Client(String accessKey,
+                                        String secretKey,
+                                        com.amazonaws.regions.Region region) {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
         try {
-            AmazonS3Client amazonS3Client = new AmazonS3Client(awsCredentials);
+            String awsRegion = null;
             if (region != null) {
-                amazonS3Client.setRegion(region);
+                awsRegion = region.getName();
             }
-            return amazonS3Client;
+            AmazonS3 s3Client = AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withRegion(awsRegion)
+                .build();
+            return s3Client;
         } catch (AmazonServiceException e) {
             String err = "Could not create connection to Amazon S3 due " +
                          "to error: " + e.getMessage();
@@ -137,7 +143,7 @@ public class S3ProviderUtil {
      * @throws IOException
      */
     public static Resource getS3ObjectByUrl(String s3Url) throws IOException {
-        AmazonS3Client client = new AmazonS3Client();
+        AmazonS3 client = AmazonS3ClientBuilder.standard().build();
         AmazonS3URI s3Uri = new AmazonS3URI(s3Url);
         S3Object s3Obj = client.getObject(new GetObjectRequest(s3Uri.getBucket(), s3Uri.getKey()));
         s3Obj.getObjectContent();

--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.AccessControlList;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
@@ -85,7 +85,7 @@ public class S3StorageProvider extends StorageProviderBase {
     protected static final String HEADER_KEY_SUFFIX = "*";
 
     private String accessKeyId = null;
-    protected AmazonS3Client s3Client = null;
+    protected AmazonS3 s3Client = null;
 
     public S3StorageProvider(String accessKey, String secretKey) {
         this(S3ProviderUtil.getAmazonS3Client(accessKey, secretKey, null),
@@ -101,7 +101,7 @@ public class S3StorageProvider extends StorageProviderBase {
              options);
     }
 
-    public S3StorageProvider(AmazonS3Client s3Client,
+    public S3StorageProvider(AmazonS3 s3Client,
                              String accessKey,
                              Map<String, String> options) {
         this.accessKeyId = accessKey;

--- a/s3storageprovider/src/main/java/org/duracloud/s3task/S3TaskProvider.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3task/S3TaskProvider.java
@@ -8,7 +8,7 @@
 package org.duracloud.s3task;
 
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storage.StringDataStoreFactory;
 import org.duracloud.s3task.storage.SetStoragePolicyTaskRunner;
@@ -36,7 +36,7 @@ public class S3TaskProvider extends TaskProviderBase {
 
     public S3TaskProvider(StorageProvider s3Provider,
                           S3StorageProvider unwrappedS3Provider,
-                          AmazonS3Client s3Client,
+                          AmazonS3 s3Client,
                           AmazonCloudFrontClient cfClient,
                           StringDataStoreFactory dataStoreFactory,
                           String cfAccountId,

--- a/s3storageprovider/src/main/java/org/duracloud/s3task/streaming/BaseStreamingTaskRunner.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3task/streaming/BaseStreamingTaskRunner.java
@@ -20,7 +20,7 @@ import com.amazonaws.services.cloudfront.model.StreamingDistributionConfig;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionList;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionSummary;
 import com.amazonaws.services.cloudfront.model.UpdateStreamingDistributionRequest;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.StorageTaskConstants;
 import org.duracloud.common.error.DuraCloudRuntimeException;
 import org.duracloud.s3storage.S3StorageProvider;
@@ -53,7 +53,7 @@ public abstract class BaseStreamingTaskRunner implements TaskRunner {
 
     protected StorageProvider s3Provider;
     protected S3StorageProvider unwrappedS3Provider;
-    protected AmazonS3Client s3Client;
+    protected AmazonS3 s3Client;
     protected AmazonCloudFrontClient cfClient;
     protected String cfAccountId;
     protected String cfKeyId;

--- a/s3storageprovider/src/main/java/org/duracloud/s3task/streaming/DeleteStreamingTaskRunner.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3task/streaming/DeleteStreamingTaskRunner.java
@@ -16,7 +16,7 @@ import com.amazonaws.services.cloudfront.model.GetStreamingDistributionConfigRes
 import com.amazonaws.services.cloudfront.model.GetStreamingDistributionRequest;
 import com.amazonaws.services.cloudfront.model.StreamingDistribution;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionSummary;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.StorageTaskConstants;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.DeleteStreamingTaskParameters;
@@ -39,7 +39,7 @@ public class DeleteStreamingTaskRunner extends BaseStreamingTaskRunner {
 
     public DeleteStreamingTaskRunner(StorageProvider s3Provider,
                                      S3StorageProvider unwrappedS3Provider,
-                                     AmazonS3Client s3Client,
+                                     AmazonS3 s3Client,
                                      AmazonCloudFrontClient cfClient) {
         this.s3Provider = s3Provider;
         this.unwrappedS3Provider = unwrappedS3Provider;

--- a/s3storageprovider/src/main/java/org/duracloud/s3task/streaming/DisableStreamingTaskRunner.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3task/streaming/DisableStreamingTaskRunner.java
@@ -9,7 +9,7 @@ package org.duracloud.s3task.streaming;
 
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionSummary;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.StorageTaskConstants;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.DisableStreamingTaskParameters;
@@ -32,7 +32,7 @@ public class DisableStreamingTaskRunner extends BaseStreamingTaskRunner {
 
     public DisableStreamingTaskRunner(StorageProvider s3Provider,
                                       S3StorageProvider unwrappedS3Provider,
-                                      AmazonS3Client s3Client,
+                                      AmazonS3 s3Client,
                                       AmazonCloudFrontClient cfClient) {
         this.s3Provider = s3Provider;
         this.unwrappedS3Provider = unwrappedS3Provider;

--- a/s3storageprovider/src/main/java/org/duracloud/s3task/streaming/EnableStreamingTaskRunner.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3task/streaming/EnableStreamingTaskRunner.java
@@ -24,7 +24,7 @@ import com.amazonaws.services.cloudfront.model.StreamingDistribution;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionConfig;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionSummary;
 import com.amazonaws.services.cloudfront.model.TrustedSigners;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.StorageTaskConstants;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.EnableStreamingTaskParameters;
@@ -48,7 +48,7 @@ public class EnableStreamingTaskRunner extends BaseStreamingTaskRunner {
 
     public EnableStreamingTaskRunner(StorageProvider s3Provider,
                                      S3StorageProvider unwrappedS3Provider,
-                                     AmazonS3Client s3Client,
+                                     AmazonS3 s3Client,
                                      AmazonCloudFrontClient cfClient,
                                      String cfAccountId) {
         this.s3Provider = s3Provider;

--- a/s3storageprovider/src/main/java/org/duracloud/s3task/streaminghls/BaseHlsTaskRunner.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3task/streaminghls/BaseHlsTaskRunner.java
@@ -21,7 +21,7 @@ import com.amazonaws.services.cloudfront.model.GetDistributionConfigResult;
 import com.amazonaws.services.cloudfront.model.ListDistributionsRequest;
 import com.amazonaws.services.cloudfront.model.Origin;
 import com.amazonaws.services.cloudfront.model.UpdateDistributionRequest;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.StorageTaskConstants;
 import org.duracloud.common.error.DuraCloudRuntimeException;
 import org.duracloud.s3storage.S3StorageProvider;
@@ -53,7 +53,7 @@ public abstract class BaseHlsTaskRunner implements TaskRunner {
 
     protected StorageProvider s3Provider;
     protected S3StorageProvider unwrappedS3Provider;
-    protected AmazonS3Client s3Client;
+    protected AmazonS3 s3Client;
     protected AmazonCloudFrontClient cfClient;
     protected String cfAccountId;
     protected String cfKeyId;

--- a/s3storageprovider/src/main/java/org/duracloud/s3task/streaminghls/DeleteHlsTaskRunner.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3task/streaminghls/DeleteHlsTaskRunner.java
@@ -16,7 +16,7 @@ import com.amazonaws.services.cloudfront.model.DistributionSummary;
 import com.amazonaws.services.cloudfront.model.GetDistributionConfigRequest;
 import com.amazonaws.services.cloudfront.model.GetDistributionConfigResult;
 import com.amazonaws.services.cloudfront.model.GetDistributionRequest;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.StorageTaskConstants;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.DeleteStreamingTaskParameters;
@@ -41,7 +41,7 @@ public class DeleteHlsTaskRunner extends BaseHlsTaskRunner {
 
     public DeleteHlsTaskRunner(StorageProvider s3Provider,
                                S3StorageProvider unwrappedS3Provider,
-                               AmazonS3Client s3Client,
+                               AmazonS3 s3Client,
                                AmazonCloudFrontClient cfClient) {
         this.s3Provider = s3Provider;
         this.unwrappedS3Provider = unwrappedS3Provider;

--- a/s3storageprovider/src/main/java/org/duracloud/s3task/streaminghls/DisableHlsTaskRunner.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3task/streaminghls/DisableHlsTaskRunner.java
@@ -9,7 +9,7 @@ package org.duracloud.s3task.streaminghls;
 
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
 import com.amazonaws.services.cloudfront.model.DistributionSummary;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.StorageTaskConstants;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.DisableStreamingTaskParameters;
@@ -32,7 +32,7 @@ public class DisableHlsTaskRunner extends BaseHlsTaskRunner {
 
     public DisableHlsTaskRunner(StorageProvider s3Provider,
                                 S3StorageProvider unwrappedS3Provider,
-                                AmazonS3Client s3Client,
+                                AmazonS3 s3Client,
                                 AmazonCloudFrontClient cfClient) {
         this.s3Provider = s3Provider;
         this.unwrappedS3Provider = unwrappedS3Provider;

--- a/s3storageprovider/src/main/java/org/duracloud/s3task/streaminghls/EnableHlsTaskRunner.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3task/streaminghls/EnableHlsTaskRunner.java
@@ -39,7 +39,7 @@ import com.amazonaws.services.cloudfront.model.Origins;
 import com.amazonaws.services.cloudfront.model.S3OriginConfig;
 import com.amazonaws.services.cloudfront.model.TrustedSigners;
 import com.amazonaws.services.cloudfront.model.ViewerProtocolPolicy;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.BucketCrossOriginConfiguration;
 import com.amazonaws.services.s3.model.CORSRule;
 import org.duracloud.StorageTaskConstants;
@@ -66,7 +66,7 @@ public class EnableHlsTaskRunner extends BaseHlsTaskRunner {
 
     public EnableHlsTaskRunner(StorageProvider s3Provider,
                                S3StorageProvider unwrappedS3Provider,
-                               AmazonS3Client s3Client,
+                               AmazonS3 s3Client,
                                AmazonCloudFrontClient cfClient,
                                String cfAccountId,
                                String dcHost) {

--- a/s3storageprovider/src/test/java/org/duracloud/s3storage/S3StorageProviderTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3storage/S3StorageProviderTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.Bucket;
@@ -71,7 +71,7 @@ import org.junit.Test;
  */
 public class S3StorageProviderTest {
 
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
     private InputStream contentStream;
 
     // Must be 20 char alphanum (and lowercase, to match bucket naming pattern)
@@ -96,7 +96,7 @@ public class S3StorageProviderTest {
     }
 
     private void setupS3Client() {
-        s3Client = createMock("AmazonS3Client", AmazonS3Client.class);
+        s3Client = createMock("AmazonS3", AmazonS3.class);
     }
 
     @Test

--- a/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/BaseStreamingTaskRunnerTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/BaseStreamingTaskRunnerTest.java
@@ -8,7 +8,7 @@
 package org.duracloud.s3task.streaming;
 
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.storage.provider.StorageProvider;
 import org.junit.Test;
@@ -21,7 +21,7 @@ public class BaseStreamingTaskRunnerTest extends StreamingTaskRunnerTestBase {
 
     protected BaseStreamingTaskRunner createRunner(StorageProvider s3Provider,
                                                    S3StorageProvider unwrappedS3Provider,
-                                                   AmazonS3Client s3Client,
+                                                   AmazonS3 s3Client,
                                                    AmazonCloudFrontClient cfClient) {
         this.s3Provider = s3Provider;
         this.unwrappedS3Provider = unwrappedS3Provider;

--- a/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/DeleteStreamingTaskRunnerTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/DeleteStreamingTaskRunnerTest.java
@@ -24,7 +24,7 @@ import com.amazonaws.services.cloudfront.model.GetStreamingDistributionResult;
 import com.amazonaws.services.cloudfront.model.StreamingDistribution;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionConfig;
 import com.amazonaws.services.cloudfront.model.UpdateStreamingDistributionRequest;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.DeleteStreamingTaskParameters;
 import org.duracloud.storage.provider.StorageProvider;
@@ -39,7 +39,7 @@ public class DeleteStreamingTaskRunnerTest extends StreamingTaskRunnerTestBase {
 
     protected DeleteStreamingTaskRunner createRunner(StorageProvider s3Provider,
                                                      S3StorageProvider unwrappedS3Provider,
-                                                     AmazonS3Client s3Client,
+                                                     AmazonS3 s3Client,
                                                      AmazonCloudFrontClient cfClient) {
         this.s3Provider = s3Provider;
         this.unwrappedS3Provider = unwrappedS3Provider;

--- a/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/DisableStreamingTaskRunnerTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/DisableStreamingTaskRunnerTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 import java.util.Map;
 
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.DisableStreamingTaskParameters;
 import org.duracloud.storage.provider.StorageProvider;
@@ -30,7 +30,7 @@ public class DisableStreamingTaskRunnerTest extends StreamingTaskRunnerTestBase 
 
     protected DisableStreamingTaskRunner createRunner(StorageProvider s3Provider,
                                                       S3StorageProvider unwrappedS3Provider,
-                                                      AmazonS3Client s3Client,
+                                                      AmazonS3 s3Client,
                                                       AmazonCloudFrontClient cfClient) {
         this.s3Provider = s3Provider;
         this.unwrappedS3Provider = unwrappedS3Provider;

--- a/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/EnableStreamingTaskRunnerTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/EnableStreamingTaskRunnerTest.java
@@ -34,7 +34,7 @@ import com.amazonaws.services.cloudfront.model.ListStreamingDistributionsResult;
 import com.amazonaws.services.cloudfront.model.StreamingDistribution;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionConfig;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionList;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.EnableStreamingTaskParameters;
 import org.duracloud.s3storageprovider.dto.EnableStreamingTaskResult;
@@ -53,7 +53,7 @@ public class EnableStreamingTaskRunnerTest extends StreamingTaskRunnerTestBase {
 
     protected EnableStreamingTaskRunner createRunner(StorageProvider s3Provider,
                                                      S3StorageProvider unwrappedS3Provider,
-                                                     AmazonS3Client s3Client,
+                                                     AmazonS3 s3Client,
                                                      AmazonCloudFrontClient cfClient,
                                                      String cfAccountId) {
         this.s3Provider = s3Provider;
@@ -199,8 +199,8 @@ public class EnableStreamingTaskRunnerTest extends StreamingTaskRunnerTestBase {
         return cfClient;
     }
 
-    protected AmazonS3Client createMockS3ClientV3() throws Exception {
-        AmazonS3Client service = EasyMock.createMock(AmazonS3Client.class);
+    protected AmazonS3 createMockS3ClientV3() throws Exception {
+        AmazonS3 service = EasyMock.createMock(AmazonS3.class);
 
         service.setBucketPolicy(EasyMock.isA(String.class),
                                 EasyMock.isA(String.class));

--- a/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/GetSignedUrlTaskRunnerTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/GetSignedUrlTaskRunnerTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.StorageTaskConstants;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.GetSignedUrlTaskParameters;
@@ -45,7 +45,7 @@ public class GetSignedUrlTaskRunnerTest extends StreamingTaskRunnerTestBase {
 
     protected GetSignedUrlTaskRunner createRunner(StorageProvider s3Provider,
                                                   S3StorageProvider unwrappedS3Provider,
-                                                  AmazonS3Client s3Client,
+                                                  AmazonS3 s3Client,
                                                   AmazonCloudFrontClient cfClient) {
         this.s3Provider = s3Provider;
         this.unwrappedS3Provider = unwrappedS3Provider;

--- a/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/GetUrlTaskRunnerTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/GetUrlTaskRunnerTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.StorageTaskConstants;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storageprovider.dto.GetUrlTaskParameters;
@@ -35,7 +35,7 @@ public class GetUrlTaskRunnerTest extends StreamingTaskRunnerTestBase {
 
     protected BaseStreamingTaskRunner createRunner(StorageProvider s3Provider,
                                                    S3StorageProvider unwrappedS3Provider,
-                                                   AmazonS3Client s3Client,
+                                                   AmazonS3 s3Client,
                                                    AmazonCloudFrontClient cfClient) {
         this.s3Provider = s3Provider;
         this.unwrappedS3Provider = unwrappedS3Provider;

--- a/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/StreamingTaskRunnerTestBase.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3task/streaming/StreamingTaskRunnerTestBase.java
@@ -19,7 +19,7 @@ import com.amazonaws.services.cloudfront.model.S3Origin;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionList;
 import com.amazonaws.services.cloudfront.model.StreamingDistributionSummary;
 import com.amazonaws.services.cloudfront.model.TrustedSigners;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.storage.error.NotFoundException;
 import org.duracloud.storage.provider.StorageProvider;
@@ -36,7 +36,7 @@ public class StreamingTaskRunnerTestBase {
 
     protected StorageProvider s3Provider;
     protected S3StorageProvider unwrappedS3Provider;
-    protected AmazonS3Client s3Client;
+    protected AmazonS3 s3Client;
     protected AmazonCloudFrontClient cfClient;
 
     protected String cfAccountId = "cf-account-id";
@@ -154,14 +154,14 @@ public class StreamingTaskRunnerTestBase {
         return provider;
     }
 
-    protected AmazonS3Client createMockS3ClientV1() throws Exception {
-        AmazonS3Client service = EasyMock.createMock(AmazonS3Client.class);
+    protected AmazonS3 createMockS3ClientV1() throws Exception {
+        AmazonS3 service = EasyMock.createMock(AmazonS3.class);
         EasyMock.replay(service);
         return service;
     }
 
-    protected AmazonS3Client createMockS3ClientV3() throws Exception {
-        AmazonS3Client service = EasyMock.createMock(AmazonS3Client.class);
+    protected AmazonS3 createMockS3ClientV3() throws Exception {
+        AmazonS3 service = EasyMock.createMock(AmazonS3.class);
 
         service.deleteBucketPolicy(EasyMock.isA(String.class));
         EasyMock.expectLastCall().once();

--- a/s3storageprovider/src/test/java/org/duracloud/s3task/streaminghls/HlsTaskRunnerTestBase.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3task/streaminghls/HlsTaskRunnerTestBase.java
@@ -21,7 +21,7 @@ import com.amazonaws.services.cloudfront.model.ListDistributionsResult;
 import com.amazonaws.services.cloudfront.model.Origin;
 import com.amazonaws.services.cloudfront.model.Origins;
 import com.amazonaws.services.cloudfront.model.TrustedSigners;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storage.StringDataStore;
 import org.duracloud.s3storage.StringDataStoreFactory;
@@ -38,7 +38,7 @@ public class HlsTaskRunnerTestBase {
 
     protected StorageProvider s3Provider;
     protected S3StorageProvider unwrappedS3Provider;
-    protected AmazonS3Client s3Client;
+    protected AmazonS3 s3Client;
     protected AmazonCloudFrontClient cfClient;
     protected StringDataStoreFactory dataStoreFactory;
     protected StringDataStore dataStore;
@@ -58,7 +58,7 @@ public class HlsTaskRunnerTestBase {
     public void setup() {
         s3Provider = EasyMock.createMock(StorageProvider.class);
         unwrappedS3Provider = EasyMock.createMock(S3StorageProvider.class);
-        s3Client = EasyMock.createMock(AmazonS3Client.class);
+        s3Client = EasyMock.createMock(AmazonS3.class);
         cfClient = EasyMock.createMock(AmazonCloudFrontClient.class);
         dataStoreFactory = EasyMock.createMock(StringDataStoreFactory.class);
         dataStore = EasyMock.createMock(StringDataStore.class);

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshotstorage/ChronopolisStorageProvider.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshotstorage/ChronopolisStorageProvider.java
@@ -9,7 +9,7 @@ package org.duracloud.snapshotstorage;
 
 import java.util.Map;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.storage.domain.StorageProviderType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ public class ChronopolisStorageProvider extends SnapshotStorageProvider {
         super(accessKey, secretKey, options);
     }
 
-    public ChronopolisStorageProvider(AmazonS3Client s3Client, String accessKey,
+    public ChronopolisStorageProvider(AmazonS3 s3Client, String accessKey,
                                       Map<String, String> options) {
         super(s3Client, accessKey, options);
     }

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshotstorage/DpnStorageProvider.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshotstorage/DpnStorageProvider.java
@@ -9,7 +9,7 @@ package org.duracloud.snapshotstorage;
 
 import java.util.Map;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.storage.domain.StorageProviderType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ public class DpnStorageProvider extends SnapshotStorageProvider {
         super(accessKey, secretKey, options);
     }
 
-    public DpnStorageProvider(AmazonS3Client s3Client, String accessKey,
+    public DpnStorageProvider(AmazonS3 s3Client, String accessKey,
                               Map<String, String> options) {
         super(s3Client, accessKey, options);
     }

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshotstorage/SnapshotStorageProvider.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshotstorage/SnapshotStorageProvider.java
@@ -9,7 +9,7 @@ package org.duracloud.snapshotstorage;
 
 import java.util.Map;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.s3storage.S3StorageProvider;
 import org.duracloud.s3storage.StoragePolicy;
 import org.slf4j.Logger;
@@ -38,7 +38,7 @@ public abstract class SnapshotStorageProvider extends S3StorageProvider {
         super(accessKey, secretKey, options);
     }
 
-    public SnapshotStorageProvider(AmazonS3Client s3Client, String accessKey,
+    public SnapshotStorageProvider(AmazonS3 s3Client, String accessKey,
                                    Map<String, String> options) {
         super(s3Client, accessKey, options);
     }

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/SnapshotTaskProvider.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/SnapshotTaskProvider.java
@@ -7,7 +7,7 @@
  */
 package org.duracloud.snapshottask;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.common.queue.TaskQueue;
 import org.duracloud.mill.manifest.ManifestStore;
 import org.duracloud.snapshotstorage.SnapshotStorageProvider;
@@ -36,7 +36,7 @@ public class SnapshotTaskProvider extends TaskProviderBase {
 
     public SnapshotTaskProvider(StorageProvider snapshotProvider,
                                 SnapshotStorageProvider unwrappedSnapshotProvider,
-                                AmazonS3Client s3Client,
+                                AmazonS3 s3Client,
                                 String dcHost,
                                 String dcPort,
                                 String dcStoreId,

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/snapshot/CleanupSnapshotTaskRunner.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/snapshot/CleanupSnapshotTaskRunner.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
 import org.duracloud.audit.task.AuditTask;
 import org.duracloud.audit.task.AuditTask.ActionType;
@@ -55,14 +55,14 @@ public class CleanupSnapshotTaskRunner implements TaskRunner {
     private static int EXPIRATION_DAYS = 1;
 
     private SnapshotStorageProvider unwrappedSnapshotProvider;
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
     private TaskQueue auditTaskQueue;
     private ManifestStore manifestStore;
     private String account;
     private String storeId;
 
     public CleanupSnapshotTaskRunner(SnapshotStorageProvider unwrappedSnapshotProvider,
-                                     AmazonS3Client s3Client,
+                                     AmazonS3 s3Client,
                                      TaskQueue auditTaskQueue,
                                      ManifestStore manifestStore,
                                      String account,

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/snapshot/CompleteRestoreTaskRunner.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/snapshot/CompleteRestoreTaskRunner.java
@@ -10,7 +10,7 @@ package org.duracloud.snapshottask.snapshot;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
 import org.duracloud.snapshot.SnapshotConstants;
 import org.duracloud.snapshot.dto.task.CompleteRestoreTaskParameters;
@@ -35,11 +35,11 @@ public class CompleteRestoreTaskRunner implements TaskRunner {
 
     private StorageProvider snapshotProvider;
     private SnapshotStorageProvider unwrappedSnapshotProvider;
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
 
     public CompleteRestoreTaskRunner(StorageProvider snapshotProvider,
                                      SnapshotStorageProvider unwrappedSnapshotProvider,
-                                     AmazonS3Client s3Client) {
+                                     AmazonS3 s3Client) {
         this.snapshotProvider = snapshotProvider;
         this.unwrappedSnapshotProvider = unwrappedSnapshotProvider;
         this.s3Client = s3Client;

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/snapshot/CompleteSnapshotTaskRunner.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/snapshot/CompleteSnapshotTaskRunner.java
@@ -9,7 +9,7 @@ package org.duracloud.snapshottask.snapshot;
 
 import java.util.HashMap;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.snapshot.SnapshotConstants;
 import org.duracloud.snapshot.dto.task.CompleteSnapshotTaskParameters;
 import org.duracloud.snapshot.dto.task.CompleteSnapshotTaskResult;
@@ -32,11 +32,11 @@ public class CompleteSnapshotTaskRunner implements TaskRunner {
 
     private StorageProvider snapshotProvider;
     private SnapshotStorageProvider unwrappedSnapshotProvider;
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
 
     public CompleteSnapshotTaskRunner(StorageProvider snapshotProvider,
                                       SnapshotStorageProvider unwrappedSnapshotProvider,
-                                      AmazonS3Client s3Client) {
+                                      AmazonS3 s3Client) {
         this.snapshotProvider = snapshotProvider;
         this.unwrappedSnapshotProvider = unwrappedSnapshotProvider;
         this.s3Client = s3Client;

--- a/snapshotstorageprovider/src/test/java/org/duracloud/snapshotstorage/SnapshotStorageProviderTest.java
+++ b/snapshotstorageprovider/src/test/java/org/duracloud/snapshotstorage/SnapshotStorageProviderTest.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.Bucket;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class SnapshotStorageProviderTest {
 
     private SnapshotStorageProvider provider;
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
 
     // Must be 20 char alphanum (and lowercase, to match bucket naming pattern)
     private static final String accessKey = "abcdefghijklmnopqrst";
@@ -34,7 +34,7 @@ public class SnapshotStorageProviderTest {
 
     @Before
     public void setup() {
-        s3Client = EasyMock.createMock("AmazonS3Client", AmazonS3Client.class);
+        s3Client = EasyMock.createMock("AmazonS3", AmazonS3.class);
         provider = new TestableSnapshotStorageProvider(s3Client, accessKey, null);
     }
 
@@ -66,7 +66,7 @@ public class SnapshotStorageProviderTest {
     }
 
     private class TestableSnapshotStorageProvider extends SnapshotStorageProvider {
-        public TestableSnapshotStorageProvider(AmazonS3Client s3Client, String accessKey,
+        public TestableSnapshotStorageProvider(AmazonS3 s3Client, String accessKey,
                                                Map<String, String> options) {
             super(s3Client, accessKey, options);
         }

--- a/snapshotstorageprovider/src/test/java/org/duracloud/snapshottask/snapshot/CleanupSnapshotTaskRunnerTest.java
+++ b/snapshotstorageprovider/src/test/java/org/duracloud/snapshottask/snapshot/CleanupSnapshotTaskRunnerTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
 import org.duracloud.audit.task.AuditTask;
 import org.duracloud.audit.task.AuditTask.ActionType;
@@ -49,7 +49,7 @@ public class CleanupSnapshotTaskRunnerTest extends EasyMockSupport {
 
     private StorageProvider snapshotProvider;
     private SnapshotStorageProvider unwrappedSnapshotProvider;
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
     private CleanupSnapshotTaskRunner taskRunner;
     private TaskQueue auditQueue;
     private String storeId = "store-id";
@@ -63,7 +63,7 @@ public class CleanupSnapshotTaskRunnerTest extends EasyMockSupport {
         unwrappedSnapshotProvider =
             createMock("SnapshotStorageProvider",
                        SnapshotStorageProvider.class);
-        s3Client = createMock("AmazonS3Client", AmazonS3Client.class);
+        s3Client = createMock("AmazonS3", AmazonS3.class);
         manifestStore = createMock("ManifestStore", ManifestStore.class);
         auditQueue = createMock("TaskQueue", TaskQueue.class);
         taskRunner =

--- a/snapshotstorageprovider/src/test/java/org/duracloud/snapshottask/snapshot/CompleteRestoreTaskRunnerTest.java
+++ b/snapshotstorageprovider/src/test/java/org/duracloud/snapshottask/snapshot/CompleteRestoreTaskRunnerTest.java
@@ -9,7 +9,7 @@ package org.duracloud.snapshottask.snapshot;
 
 import static org.junit.Assert.assertEquals;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.BucketLifecycleConfiguration;
 import org.duracloud.snapshotstorage.SnapshotStorageProvider;
 import org.duracloud.storage.provider.StorageProvider;
@@ -27,7 +27,7 @@ public class CompleteRestoreTaskRunnerTest {
 
     private StorageProvider snapshotProvider;
     private SnapshotStorageProvider unwrappedSnapshotProvider;
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
     private CompleteRestoreTaskRunner taskRunner;
 
     @Before
@@ -37,7 +37,7 @@ public class CompleteRestoreTaskRunnerTest {
         unwrappedSnapshotProvider =
             EasyMock.createMock("SnapshotStorageProvider",
                                 SnapshotStorageProvider.class);
-        s3Client = EasyMock.createMock("AmazonS3Client", AmazonS3Client.class);
+        s3Client = EasyMock.createMock("AmazonS3", AmazonS3.class);
         taskRunner = new CompleteRestoreTaskRunner(snapshotProvider,
                                                    unwrappedSnapshotProvider,
                                                    s3Client);

--- a/snapshotstorageprovider/src/test/java/org/duracloud/snapshottask/snapshot/CompleteSnapshotTaskRunnerTest.java
+++ b/snapshotstorageprovider/src/test/java/org/duracloud/snapshottask/snapshot/CompleteSnapshotTaskRunnerTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Map;
 
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3;
 import org.duracloud.snapshotstorage.SnapshotStorageProvider;
 import org.duracloud.storage.provider.StorageProvider;
 import org.easymock.EasyMock;
@@ -27,7 +27,7 @@ public class CompleteSnapshotTaskRunnerTest {
 
     private StorageProvider snapshotProvider;
     private SnapshotStorageProvider unwrappedSnapshotProvider;
-    private AmazonS3Client s3Client;
+    private AmazonS3 s3Client;
     private CompleteSnapshotTaskRunner taskRunner;
 
     @Before
@@ -37,7 +37,7 @@ public class CompleteSnapshotTaskRunnerTest {
         unwrappedSnapshotProvider =
             EasyMock.createMock("SnapshotStorageProvider",
                                 SnapshotStorageProvider.class);
-        s3Client = EasyMock.createMock("AmazonS3Client", AmazonS3Client.class);
+        s3Client = EasyMock.createMock("AmazonS3", AmazonS3.class);
         taskRunner = new CompleteSnapshotTaskRunner(snapshotProvider,
                                                     unwrappedSnapshotProvider,
                                                     s3Client);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1219

# What does this Pull Request do?

The AWS Java SDK AmazonS3Client class is now deprecated. These changes
migrate to the newer AmazonS3 class and use the preferred
AmazonS3ClientBuilder constructor.

# How should this be tested?

There should be no difference in functionality so running the regular tests will be fine.

# Additional Notes:

If there are other projects calling this, they should be updated to expect an AmazonS3 class instead of an AmazonS3Client class. Otherwise, the methods are all the same.

# Interested parties
@bbranan 
