### PR TITLE
Sets the region in the S3Client based on AWS_REGION system property

### DIFF
--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
@@ -8,6 +8,7 @@
 package org.duracloud.s3storage;
 
 import static org.duracloud.common.error.RetryFlaggableException.RETRY;
+import static org.duracloud.storage.domain.StorageAccount.OPTS.AWS_REGION;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -23,7 +24,6 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
-import org.duracloud.storage.domain.StorageAccount;
 import org.duracloud.storage.error.StorageException;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
@@ -47,9 +47,9 @@ public class S3ProviderUtil {
         AmazonS3 client = s3Clients.get(key(accessKey, secretKey));
         if (null == client) {
             Region region = null;
-            if (options != null && options.get(StorageAccount.OPTS.AWS_REGION.name()) != null) {
+            if (options != null && options.get(AWS_REGION.name()) != null) {
                 region = com.amazonaws.services.s3.model.Region.fromValue(
-                    options.get(StorageAccount.OPTS.AWS_REGION.name())).toAWSRegion();
+                    options.get(AWS_REGION.name())).toAWSRegion();
             }
             client = newS3Client(accessKey, secretKey, region);
             s3Clients.put(key(accessKey, secretKey), client);
@@ -63,12 +63,14 @@ public class S3ProviderUtil {
 
     private static AmazonS3 newS3Client(String accessKey,
                                         String secretKey,
-                                        com.amazonaws.regions.Region region) {
+                                        Region region) {
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
         try {
             String awsRegion = null;
             if (region != null) {
                 awsRegion = region.getName();
+            } else {
+                awsRegion = System.getProperty(AWS_REGION.name());
             }
             AmazonS3 s3Client = AmazonS3ClientBuilder
                 .standard()


### PR DESCRIPTION
**JIRA Ticket**:

Follow on to https://jira.duraspace.org/browse/DURACLOUD-1219. The updated client requires a default region setting.

# What does this Pull Request do?

Checks for a Java system property named AWS_REGION for the default region value. If there is no property with that key set, the region is set to null, which allows for the client to pick up the region from the environment (as an environment variable or from an aws config file).

# How should this be tested?

Deploy the web applications without setting AWS_REGION, verify that there are region errors. Add the AWS_REGION system property, verify that DurAdmin loads correctly.

# Interested parties
@dbernstein 
