### PR TITLE
DURACLOUD-1222: Ensures that S3 client cache differentiates between clients with different options (primarily region)

### DIFF
--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
@@ -44,7 +44,7 @@ public class S3ProviderUtil {
     public static AmazonS3 getAmazonS3Client(String accessKey,
                                              String secretKey,
                                              Map<String, String> options) {
-        AmazonS3 client = s3Clients.get(key(accessKey, secretKey));
+        AmazonS3 client = s3Clients.get(key(accessKey, secretKey, options));
         if (null == client) {
             Region region = null;
             if (options != null && options.get(AWS_REGION.name()) != null) {
@@ -52,13 +52,17 @@ public class S3ProviderUtil {
                     options.get(AWS_REGION.name())).toAWSRegion();
             }
             client = newS3Client(accessKey, secretKey, region);
-            s3Clients.put(key(accessKey, secretKey), client);
+            s3Clients.put(key(accessKey, secretKey, options), client);
         }
         return client;
     }
 
-    private static String key(String accessKey, String secretKey) {
-        return accessKey + secretKey;
+    private static String key(String accessKey, String secretKey, Map<String, String> options) {
+        String optionsHash = "";
+        if (null != options && options.size() > 0) {
+            optionsHash = Integer.toString(options.hashCode());
+        }
+        return accessKey + secretKey + optionsHash;
     }
 
     private static AmazonS3 newS3Client(String accessKey,
@@ -88,10 +92,10 @@ public class S3ProviderUtil {
     public static AmazonCloudFrontClient getAmazonCloudFrontClient(String accessKey,
                                                                    String secretKey) {
         AmazonCloudFrontClient client =
-            cloudFrontClients.get(key(accessKey, secretKey));
+            cloudFrontClients.get(key(accessKey, secretKey, null));
         if (null == client) {
             client = newAmazonCloudFrontClient(accessKey, secretKey);
-            cloudFrontClients.put(key(accessKey, secretKey), client);
+            cloudFrontClients.put(key(accessKey, secretKey, null), client);
         }
         return client;
     }

--- a/s3storageprovider/src/test/java/org/duracloud/s3storage/S3ProviderUtilTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3storage/S3ProviderUtilTest.java
@@ -10,6 +10,7 @@ package org.duracloud.s3storage;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotSame;
 import static org.duracloud.storage.domain.StorageAccount.OPTS.AWS_REGION;
+import static org.junit.Assert.assertSame;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +41,7 @@ public class S3ProviderUtilTest {
     }
 
     @Test
-    public void testGetAmazonS3Client() {
+    public void testGetDifferentAmazonS3Clients() {
         String accessKey = "access-key";
         String privateKey = "private-key";
 
@@ -59,4 +60,23 @@ public class S3ProviderUtilTest {
         assertNotSame(s3ClientA, s3ClientB);
     }
 
+    @Test
+    public void testGetSameAmazonS3Clients() {
+        String accessKey = "access-key";
+        String privateKey = "private-key";
+
+        Map<String, String> optionsA = new HashMap<>();
+        optionsA.put(AWS_REGION.name(), "us-east-1");
+
+        Map<String, String> optionsB = new HashMap<>();
+        optionsB.put(AWS_REGION.name(), "us-east-1");
+
+        AmazonS3 s3ClientA = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsA);
+        assertEquals("us-east-1", s3ClientA.getRegionName());
+
+        AmazonS3 s3ClientB = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsB);
+        assertEquals("us-east-1", s3ClientB.getRegionName());
+
+        assertSame(s3ClientA, s3ClientB);
+    }
 }

--- a/s3storageprovider/src/test/java/org/duracloud/s3storage/S3ProviderUtilTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3storage/S3ProviderUtilTest.java
@@ -8,7 +8,13 @@
 package org.duracloud.s3storage;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotSame;
+import static org.duracloud.storage.domain.StorageAccount.OPTS.AWS_REGION;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.amazonaws.services.s3.AmazonS3;
 import org.junit.Test;
 
 /**
@@ -32,4 +38,25 @@ public class S3ProviderUtilTest {
                                                         "x--..y..--z-.");
         assertEquals("abc.x-y.z", bucketName);
     }
+
+    @Test
+    public void testGetAmazonS3Client() {
+        String accessKey = "access-key";
+        String privateKey = "private-key";
+
+        Map<String, String> optionsA = new HashMap<>();
+        optionsA.put(AWS_REGION.name(), "us-east-1");
+
+        Map<String, String> optionsB = new HashMap<>();
+        optionsB.put(AWS_REGION.name(), "us-west-2");
+
+        AmazonS3 s3ClientA = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsA);
+        assertEquals("us-east-1", s3ClientA.getRegionName());
+
+        AmazonS3 s3ClientB = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsB);
+        assertEquals("us-west-2", s3ClientB.getRegionName());
+
+        assertNotSame(s3ClientA, s3ClientB);
+    }
+
 }


### PR DESCRIPTION
**JIRA Ticket**:

https://jira.duraspace.org/browse/DURACLOUD-1222

# What does this Pull Request do?

Ensures that S3 clients that are created with different optional parameters (primarily region) result in distinct entries in the cache.

# How should this be tested?

Create a storage provider with a region setting. Verify that buckets created for that provider are in the expected region. Change the region setting. Verify that buckets created for the provider are in the new region.

Example:
* Does this change require documentation to be updated?  No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers

@dbernstein 
