### PR TITLE
Removes call to send notification to clear account cache when content properties are updated

### DIFF
--- a/durastore/src/main/java/org/duracloud/durastore/util/ACLStorageProvider.java
+++ b/durastore/src/main/java/org/duracloud/durastore/util/ACLStorageProvider.java
@@ -375,7 +375,6 @@ public class ACLStorageProvider implements StorageProvider {
         targetProvider.setContentProperties(spaceId,
                                             contentId,
                                             contentProperties);
-        sendCacheChangedNotification();
     }
 
     @Override


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1225

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?

Removes the call in ACLStorageProvider.setContentProperties() that sends a notification to DuraStore/DurAdmin to reset the account cache.

# How should this be tested?

Once deployed, verify that when making a call to set content properties an SQS message does not get sent with type STORAGE_PROVIDER_CACHE_ON_NODE_CHANGED

Example:
* Does this change require documentation to be updated?  No
* Does this change add any new dependencies?  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
@dbernstein 