### PR TITLE
Add S3 Swift storage provider

### DIFF
--- a/auditor/src/main/java/org/duracloud/audit/reader/impl/AuditLogReaderImpl.java
+++ b/auditor/src/main/java/org/duracloud/audit/reader/impl/AuditLogReaderImpl.java
@@ -139,7 +139,7 @@ public class AuditLogReaderImpl implements AuditLogReader {
                  new BufferedReader(new InputStreamReader(
                      storageProvider.getContent(auditSpaceId, contentId).getContentStream()))) {
             if (count > 0) {
-                // skip header if not hte first file
+                // skip header if not the first file
                 reader.readLine();
             }
 

--- a/duradmin/src/main/resources/messages_en.properties
+++ b/duradmin/src/main/resources/messages_en.properties
@@ -18,6 +18,7 @@ storageProviders=Storage Providers
 #storage provider types
 amazon_s3=Amazon S3
 amazon_glacier=Amazon Glacier
+swift_s3=Swift S3
 irods=iRODS
 chronopolis=Chronopolis
 test_verify_create=Test Verify Create

--- a/duradmin/src/main/webapp/jquery/dc/ext/jquery.dc.common.js
+++ b/duradmin/src/main/webapp/jquery/dc/ext/jquery.dc.common.js
@@ -321,6 +321,7 @@ $(function(){
 		var spNameMap = {};
 		spNameMap["AMAZON_S3"] = "Amazon S3";
 		spNameMap["AMAZON_GLACIER"] = "Amazon Glacier";
+                spNameMap["SWIFT_S3"] = "Swift S3";
 		spNameMap["CHRONOPOLIS"] = "Chronopolis";
 		spNameMap["IRODS"] = "iRODS";
 		dc.STORAGE_PROVIDER_KEY_MAP = spNameMap;

--- a/durastore/pom.xml
+++ b/durastore/pom.xml
@@ -167,6 +167,12 @@
 
     <dependency>
       <groupId>org.duracloud</groupId>
+      <artifactId>swiftstorageprovider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.duracloud</groupId>
       <artifactId>storageproviderdata</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/durastore/src/main/java/org/duracloud/durastore/util/StorageProviderFactoryImpl.java
+++ b/durastore/src/main/java/org/duracloud/durastore/util/StorageProviderFactoryImpl.java
@@ -39,6 +39,7 @@ import org.duracloud.storage.provider.StatelessStorageProvider;
 import org.duracloud.storage.provider.StorageProvider;
 import org.duracloud.storage.provider.StorageProviderBase;
 import org.duracloud.storage.util.StorageProviderFactory;
+import org.duracloud.swiftstorage.SwiftStorageProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -210,6 +211,10 @@ public class StorageProviderFactoryImpl extends ProviderFactoryBase
             storageProvider = new S3StorageProvider(username,
                                                     password,
                                                     account.getOptions());
+        } else if (type.equals(StorageProviderType.SWIFT_S3)) {
+            storageProvider = new SwiftStorageProvider(username,
+                                                       password,
+                                                       account.getOptions());
         } else if (type.equals(StorageProviderType.AMAZON_GLACIER)) {
             storageProvider = new GlacierStorageProvider(username,
                                                          password,

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <module>storageproviderdata</module>
     <module>s3storageprovider</module>
     <module>glacierstorageprovider</module>
+    <module>swiftstorageprovider</module>
     <module>irodsstorageprovider</module>
     <module>snapshotdata</module>
     <module>snapshotstorageprovider</module>
@@ -234,7 +235,7 @@
     <instrumentedTests>**/*Test*__*.class</instrumentedTests>
     <innerClasses>**/*$*</innerClasses>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <duracloud.db.version>6.0.0</duracloud.db.version>
+    <duracloud.db.version>6.1.0-SNAPSHOT</duracloud.db.version>
     <org.springframework.version>4.2.5.RELEASE</org.springframework.version>
     <org.springframework.security.version>4.0.4.RELEASE</org.springframework.security.version>
     <org.springframework.webflow.version>2.4.2.RELEASE</org.springframework.webflow.version>

--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
@@ -8,15 +8,19 @@
 package org.duracloud.s3storage;
 
 import static org.duracloud.common.error.RetryFlaggableException.RETRY;
-import static org.duracloud.storage.domain.StorageAccount.OPTS.AWS_REGION;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Region;
 import com.amazonaws.services.cloudfront.AmazonCloudFrontClient;
 import com.amazonaws.services.s3.AmazonS3;
@@ -24,7 +28,10 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import org.duracloud.storage.domain.StorageAccount.OPTS;
 import org.duracloud.storage.error.StorageException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 
@@ -33,6 +40,8 @@ import org.springframework.core.io.Resource;
  * Date: May 20, 2010
  */
 public class S3ProviderUtil {
+
+    private static final Logger log = LoggerFactory.getLogger(S3ProviderUtil.class);
 
     private static Map<String, AmazonS3> s3Clients = new HashMap<>();
     private static Map<String, AmazonCloudFrontClient> cloudFrontClients = new HashMap<>();
@@ -47,11 +56,25 @@ public class S3ProviderUtil {
         AmazonS3 client = s3Clients.get(key(accessKey, secretKey, options));
         if (null == client) {
             Region region = null;
-            if (options != null && options.get(AWS_REGION.name()) != null) {
-                region = com.amazonaws.services.s3.model.Region.fromValue(
-                    options.get(AWS_REGION.name())).toAWSRegion();
+            URL endpoint = null;
+            String signer = null;
+            if (options != null) {
+                if (options.get(OPTS.SWIFT_S3_ENDPOINT.name()) != null) {
+                    try {
+                        endpoint = new URL(options.get(OPTS.SWIFT_S3_ENDPOINT.name()));
+                    } catch (MalformedURLException e) {
+                        String err = "The provided Swift S3 Endpoint URL is invalid: " + e.getMessage();
+                        throw new StorageException(err, e);
+                    }
+                    if (options.get(OPTS.SWIFT_S3_SIGNER_TYPE.name()) != null) {
+                        signer = options.get(OPTS.SWIFT_S3_SIGNER_TYPE.name());
+                    }
+                } else if (options.get(OPTS.AWS_REGION.name()) != null) {
+                    region = com.amazonaws.services.s3.model.Region.fromValue(
+                            options.get(OPTS.AWS_REGION.name())).toAWSRegion();
+                }
             }
-            client = newS3Client(accessKey, secretKey, region);
+            client = newS3Client(accessKey, secretKey, region, endpoint, signer);
             s3Clients.put(key(accessKey, secretKey, options), client);
         }
         return client;
@@ -67,24 +90,65 @@ public class S3ProviderUtil {
 
     private static AmazonS3 newS3Client(String accessKey,
                                         String secretKey,
-                                        Region region) {
+                                        Region region,
+                                        URL endpoint,
+                                        String signer) {
         BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        AmazonS3 s3Client = null;
+        String awsRegion = null;
         try {
-            String awsRegion = null;
-            if (region != null) {
-                awsRegion = region.getName();
+            if (endpoint == null) {
+                if (region != null) {
+                    awsRegion = region.getName();
+                } else {
+                    awsRegion = System.getProperty(OPTS.AWS_REGION.name());
+                }
+                // Construct a normal client that connects to AWS.
+                log.debug("Creating AWS S3 Client.");
+                s3Client = AmazonS3ClientBuilder
+                    .standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                    .withRegion(awsRegion)
+                    .build();
             } else {
-                awsRegion = System.getProperty(AWS_REGION.name());
+                // Construct a client that will work with S3+Swift
+                log.debug("Creating Swift S3 client.");
+                String protocol = endpoint.getProtocol();
+                String host = endpoint.getAuthority();
+                String ref = endpoint.getRef();
+                String endpointString = protocol + "://" + host;
+                ClientConfiguration clientConfiguration = new ClientConfiguration();
+                clientConfiguration.setProtocol(Protocol.valueOf(protocol.toUpperCase()));
+
+                if (signer != null) {
+                    clientConfiguration.setSignerOverride(signer);
+                }
+
+                if (ref == null) {
+                    // Still must be a valid AWS region for certain signer types,
+                    // even though it isn't used.
+                    awsRegion = "us-east-1";
+                } else {
+                    awsRegion = ref;
+                }
+
+                s3Client = AmazonS3ClientBuilder
+                    .standard()
+                    .withEndpointConfiguration(
+                        new AwsClientBuilder.EndpointConfiguration(
+                            endpointString, awsRegion
+                        )
+                    )
+                    .withPathStyleAccessEnabled(true)
+                    .withClientConfiguration(clientConfiguration)
+                    .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                    .build();
             }
-            AmazonS3 s3Client = AmazonS3ClientBuilder
-                .standard()
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                .withRegion(awsRegion)
-                .build();
             return s3Client;
         } catch (AmazonServiceException e) {
-            String err = "Could not create connection to Amazon S3 due " +
-                         "to error: " + e.getMessage();
+            String connType = endpoint == null ? "Amazon" : "Swift";
+            String err = "Could not create connection to " + connType + " S3 due "
+                + "to error: " + e.getMessage();
             throw new StorageException(err, e, RETRY);
         }
     }

--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
@@ -84,7 +84,7 @@ public class S3StorageProvider extends StorageProviderBase {
     protected static final String HEADER_VALUE_PREFIX = UTF_8 + "''";
     protected static final String HEADER_KEY_SUFFIX = "*";
 
-    private String accessKeyId = null;
+    protected String accessKeyId = null;
     protected AmazonS3 s3Client = null;
 
     public S3StorageProvider(String accessKey, String secretKey) {
@@ -248,7 +248,7 @@ public class S3StorageProvider extends StorageProviderBase {
         }
     }
 
-    private Bucket createBucket(String spaceId) {
+    protected Bucket createBucket(String spaceId) {
         String bucketName = getNewBucketName(spaceId);
         try {
             Bucket bucket = s3Client.createBucket(bucketName);
@@ -429,7 +429,7 @@ public class S3StorageProvider extends StorageProviderBase {
         return String.valueOf(count) + suffix;
     }
 
-    private String getBucketCreationDate(String bucketName) {
+    protected String getBucketCreationDate(String bucketName) {
         Date created = null;
         try {
             List<Bucket> buckets = s3Client.listBuckets();
@@ -494,7 +494,7 @@ public class S3StorageProvider extends StorageProviderBase {
      * Performs a replaceAll of one string value for another in all the values
      * of a map.
      */
-    private Map<String, String> replaceInMapValues(Map<String, String> map,
+    protected Map<String, String> replaceInMapValues(Map<String, String> map,
                                                    String oldVal,
                                                    String newVal) {
         for (String key : map.keySet()) {

--- a/s3storageprovider/src/test/java/org/duracloud/s3storage/S3ProviderUtilTest.java
+++ b/s3storageprovider/src/test/java/org/duracloud/s3storage/S3ProviderUtilTest.java
@@ -9,7 +9,7 @@ package org.duracloud.s3storage;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotSame;
-import static org.duracloud.storage.domain.StorageAccount.OPTS.AWS_REGION;
+import static org.duracloud.storage.domain.StorageAccount.OPTS;
 import static org.junit.Assert.assertSame;
 
 import java.util.HashMap;
@@ -46,10 +46,10 @@ public class S3ProviderUtilTest {
         String privateKey = "private-key";
 
         Map<String, String> optionsA = new HashMap<>();
-        optionsA.put(AWS_REGION.name(), "us-east-1");
+        optionsA.put(OPTS.AWS_REGION.name(), "us-east-1");
 
         Map<String, String> optionsB = new HashMap<>();
-        optionsB.put(AWS_REGION.name(), "us-west-2");
+        optionsB.put(OPTS.AWS_REGION.name(), "us-west-2");
 
         AmazonS3 s3ClientA = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsA);
         assertEquals("us-east-1", s3ClientA.getRegionName());
@@ -66,16 +66,52 @@ public class S3ProviderUtilTest {
         String privateKey = "private-key";
 
         Map<String, String> optionsA = new HashMap<>();
-        optionsA.put(AWS_REGION.name(), "us-east-1");
+        optionsA.put(OPTS.AWS_REGION.name(), "us-east-1");
 
         Map<String, String> optionsB = new HashMap<>();
-        optionsB.put(AWS_REGION.name(), "us-east-1");
+        optionsB.put(OPTS.AWS_REGION.name(), "us-east-1");
 
         AmazonS3 s3ClientA = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsA);
         assertEquals("us-east-1", s3ClientA.getRegionName());
 
         AmazonS3 s3ClientB = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsB);
         assertEquals("us-east-1", s3ClientB.getRegionName());
+
+        assertSame(s3ClientA, s3ClientB);
+    }
+
+    @Test
+    public void testGetDifferentSwiftS3Clients() {
+        String accessKey = "access-key";
+        String privateKey = "private-key";
+
+        Map<String, String> optionsA = new HashMap<>();
+        optionsA.put(OPTS.SWIFT_S3_ENDPOINT.name(), "https://my.endpoint.com#us-east-1");
+
+        Map<String, String> optionsB = new HashMap<>();
+        optionsB.put(OPTS.SWIFT_S3_ENDPOINT.name(), "https://my.other-endpoint.com#us-west-1");
+
+        AmazonS3 s3ClientA = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsA);
+
+        AmazonS3 s3ClientB = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsB);
+
+        assertNotSame(s3ClientA, s3ClientB);
+    }
+
+    @Test
+    public void testGetSameSwiftS3Clients() {
+        String accessKey = "access-key";
+        String privateKey = "private-key";
+
+        Map<String, String> optionsA = new HashMap<>();
+        optionsA.put(OPTS.SWIFT_S3_ENDPOINT.name(), "https://my.endpoint.com#us-east-1");
+
+        Map<String, String> optionsB = new HashMap<>();
+        optionsB.put(OPTS.SWIFT_S3_ENDPOINT.name(), "https://my.endpoint.com#us-east-1");
+
+        AmazonS3 s3ClientA = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsA);
+
+        AmazonS3 s3ClientB = S3ProviderUtil.getAmazonS3Client(accessKey, privateKey, optionsB);
 
         assertSame(s3ClientA, s3ClientB);
     }

--- a/storageprovider/src/main/java/org/duracloud/storage/domain/StorageAccount.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/domain/StorageAccount.java
@@ -25,6 +25,9 @@ public interface StorageAccount {
         CF_KEY_ID,
         CF_KEY_PATH,
         AWS_REGION,
+        // Swift
+        SWIFT_S3_ENDPOINT,
+        SWIFT_S3_SIGNER_TYPE,
         // iRODS below
         ZONE,
         PORT,

--- a/swiftstorageprovider/pom.xml
+++ b/swiftstorageprovider/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.duracloud</groupId>
+  <artifactId>swiftstorageprovider</artifactId>
+  <version>6.1.0-SNAPSHOT</version>
+  <name>Swift Storage Provider</name>
+
+  <parent>
+    <artifactId>duracloud</artifactId>
+    <groupId>org.duracloud</groupId>
+    <version>6.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+    
+  <dependencies>
+
+    <dependency>
+      <groupId>org.duracloud</groupId>
+      <artifactId>s3storageprovider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.duracloud</groupId>
+      <artifactId>storageprovider</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Amazon library for accessing AWS services, including S3 -->
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/swiftstorageprovider/src/main/java/org/duracloud/swiftstorage/SwiftStorageProvider.java
+++ b/swiftstorageprovider/src/main/java/org/duracloud/swiftstorage/SwiftStorageProvider.java
@@ -1,0 +1,164 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.swiftstorage;
+
+import static org.duracloud.common.error.RetryFlaggableException.RETRY;
+import static org.duracloud.storage.provider.StorageProvider.PROPERTIES_SPACE_COUNT;
+import static org.duracloud.storage.provider.StorageProvider.PROPERTIES_SPACE_CREATED;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.Bucket;
+import org.apache.commons.lang.StringUtils;
+import org.duracloud.s3storage.S3ProviderUtil;
+import org.duracloud.s3storage.S3StorageProvider;
+import org.duracloud.storage.domain.StorageProviderType;
+import org.duracloud.storage.error.NotFoundException;
+import org.duracloud.storage.error.StorageException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides content storage backed by OpenStack Swift with S3 API middleware.
+ *
+ * @author Andy Foster
+ * Date: Feb 25, 2019
+ */
+public class SwiftStorageProvider extends S3StorageProvider {
+
+    private final Logger log = LoggerFactory.getLogger(SwiftStorageProvider.class);
+
+    public SwiftStorageProvider(String accessKey, String secretKey, Map<String, String> options) {
+        super(accessKey, secretKey, options);
+    }
+
+    public SwiftStorageProvider(AmazonS3 s3Client, String accessKey) {
+        super(s3Client, accessKey, null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public StorageProviderType getStorageProviderType() {
+        return StorageProviderType.SWIFT_S3;
+    }
+
+    @Override
+    protected Bucket createBucket(String spaceId) {
+        String bucketName = getNewBucketName(spaceId);
+        try {
+            Bucket bucket = s3Client.createBucket(bucketName);
+
+            // Swift has no concept of bucket lifecycle
+
+            return bucket;
+        } catch (AmazonClientException e) {
+            String err = "Could not create S3 bucket with name " + bucketName
+                         + " due to error: " + e.getMessage();
+            throw new StorageException(err, e, RETRY);
+        }
+    }
+
+    // Swift access keys are longer than 20 characters, and creating
+    // a bucket starting with your access key causes problems.
+    @Override
+    protected String getNewBucketName(String spaceId) {
+        String truncatedKey = truncateKey(accessKeyId);
+        return S3ProviderUtil.createNewBucketName(truncatedKey, spaceId);
+    }
+
+    @Override
+    protected String getSpaceId(String bucketName) {
+        String spaceId = bucketName;
+        String truncatedKey = truncateKey(accessKeyId);
+        if (isSpace(bucketName)) {
+            spaceId = spaceId.substring(truncatedKey.length() + 1);
+        }
+        return spaceId;
+    }
+
+    @Override
+    protected Map<String, String> getAllSpaceProperties(String spaceId) {
+        log.debug("getAllSpaceProperties(" + spaceId + ")");
+
+        // Will throw if bucket does not exist
+        String bucketName = getBucketName(spaceId);
+
+        // Retrieve space properties from metadata file
+        String propsAsString = s3Client.getObjectAsString(bucketName, "SpaceMetadata");
+        // Decode this string into a HashMap
+        Map<String, String> spaceProperties = new HashMap<>();
+        // Remove the {} from the string
+        propsAsString = propsAsString.substring(1, propsAsString.length() - 1);
+
+        String[] propsList = propsAsString.split(", ");
+        for (String prop : propsList) {
+            String[] props = prop.split("=");
+            spaceProperties.put(props[0], props[1]);
+        }
+
+        // Handle @ symbol (change from +), to allow for email usernames in ACLs
+        spaceProperties = replaceInMapValues(spaceProperties, "+", "@");
+
+        // Add space count
+        spaceProperties.put(PROPERTIES_SPACE_COUNT,
+                            getSpaceCount(spaceId, MAX_ITEM_COUNT));
+
+        return spaceProperties;
+    }
+
+    @Override
+    protected void doSetSpaceProperties(String spaceId,
+                                        Map<String, String> spaceProperties) {
+        log.debug("setSpaceProperties(" + spaceId + ")");
+
+        // Will throw if bucket does not exist
+        String bucketName = getBucketName(spaceId);
+
+        Map<String, String> originalProperties;
+        try {
+            originalProperties = getAllSpaceProperties(spaceId);
+        } catch (NotFoundException e) {
+            // Likely adding a new space, so no existing properties yet.
+            originalProperties = new HashMap<>();
+        }
+
+        // Set creation date
+        String creationDate = originalProperties.get(PROPERTIES_SPACE_CREATED);
+        if (creationDate == null) {
+            creationDate = spaceProperties.get(PROPERTIES_SPACE_CREATED);
+            if (creationDate == null) {
+                // getBucketCreationDate does not work with Swift.
+                // Best we can do here is use current time.
+                DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+                creationDate = dateFormat.format(new Date());
+            }
+        }
+        spaceProperties.put(PROPERTIES_SPACE_CREATED, creationDate);
+
+        // Handle @ symbol (change to +), to allow for email usernames in ACLs
+        spaceProperties = replaceInMapValues(spaceProperties, "@", "+");
+
+        // Store properties
+        // Swift has no concept of tags, so we're going to store properties in
+        // an object in this bucket instead.
+        s3Client.putObject(bucketName, "SpaceMetadata", spaceProperties.toString());
+    }
+
+    private String truncateKey(String accessKey)  {
+        // Convert access key to 20 character string
+        return StringUtils.left(accessKey, 20);
+    }
+}

--- a/swiftstorageprovider/src/test/java/org/duracloud/swiftstorage/SwiftStorageProviderTest.java
+++ b/swiftstorageprovider/src/test/java/org/duracloud/swiftstorage/SwiftStorageProviderTest.java
@@ -1,0 +1,46 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.duracloud.swiftstorage;
+
+import static org.easymock.EasyMock.createMock;
+import static org.junit.Assert.assertEquals;
+
+import com.amazonaws.services.s3.AmazonS3;
+import org.duracloud.storage.domain.StorageProviderType;
+import org.junit.Test;
+
+/**
+ *
+ * @author fostera
+ */
+
+public class SwiftStorageProviderTest {
+
+    private AmazonS3 s3Client;
+
+    // In OpenStack, access keys are 32 bytes in length.
+    private static final String accessKey = "c09417d8d454dff21664a30f1e734149";
+    private static final String secretKey = "secretKey";
+    private static final String contentId = "content-id";
+    private static final String spaceId = "space-id";
+
+    private void setupS3Client() {
+        s3Client = createMock("AmazonS3", AmazonS3.class);
+    }
+
+    @Test
+    public void testGetStorageProviderType() {
+        SwiftStorageProvider provider = new SwiftStorageProvider(accessKey, secretKey, null);
+        assertEquals(StorageProviderType.SWIFT_S3, provider.getStorageProviderType());
+    }
+
+    @Test
+    public void testGetNewBucketName() {
+        SwiftStorageProvider provider = new SwiftStorageProvider(accessKey, secretKey, null);
+        String bucketName = provider.getNewBucketName(spaceId);
+        assertEquals(bucketName, "c09417d8d454dff21664.space-id");
+    }
+}


### PR DESCRIPTION
# What does this Pull Request do?

This commit adds a new storage option - OpenStack Swift with S3
middleware.

We have written a new module called swiftstorageprovider which overrides
the methods in s3storageprovider that Swift does not support.

S3ProviderUtil is now capable of constructing S3 clients compatible with
both AWS and Swift, and handles the options passed in for Swift clients.

# How should this be tested?

To fully test this, one needs an S3 compatible OpenStack Swift backend.

* Create a new account with S3 Swift as the primary storage option.
* Configure the provider with the appropriate access key, secret key, S3 Endpoint and Signer Type.
* The Endpoint URL should be of the form `http(s)://my.s3.endpoint#Region`. The region is optional as it is only necessary for certain signer types. If you don't need to specify a region, omit the `#`.
* Log in to the account and try to create a space, upload content, delete content, delete the space etc.

# Additional Notes:

Known issues:

* HLS streaming does not work
* Because the management of the audit log space is decoupled from the storage providers, users still need an AWS S3 account for the audit bucket.

Additional documentation is required detailing how to use this storage option.

# Interested parties
@bbranan 
