### PR TITLE
Duracloud 680: Adds vertical, horizontal scrollbars to details pane so that text and buttons are accessible in sm…

### DIFF
--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -2328,7 +2328,7 @@ $(function() {
   $.widget("ui.basedetailpane", $.extend({}, $.ui.basepane.prototype, {
     _layoutOptions : {
       north__paneSelector : ".north",
-      north__size : 100,
+      north__size : 115,
       center__paneSelector : ".center",
       resizable : false,
       slidable : false,
@@ -3814,7 +3814,7 @@ $(function() {
     _contentItem : null,
 
     _layoutOptions : $.extend(true, {}, $.ui.spacesdetail.prototype._layoutOptions, {
-      north__size : 150,
+      north__size : 165,
     }),
     _init : function() {
       $.ui.basedetailpane.prototype._init.call(this);

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -2328,7 +2328,7 @@ $(function() {
   $.widget("ui.basedetailpane", $.extend({}, $.ui.basepane.prototype, {
     _layoutOptions : {
       north__paneSelector : ".north",
-      north__size : 115,
+      north__size : 100,
       center__paneSelector : ".center",
       resizable : false,
       slidable : false,
@@ -3814,7 +3814,7 @@ $(function() {
     _contentItem : null,
 
     _layoutOptions : $.extend(true, {}, $.ui.spacesdetail.prototype._layoutOptions, {
-      north__size : 165,
+      north__size : 150,
     }),
     _init : function() {
       $.ui.basedetailpane.prototype._init.call(this);

--- a/duradmin/src/main/webapp/style/base.css
+++ b/duradmin/src/main/webapp/style/base.css
@@ -653,7 +653,8 @@ input.dc-check-all
 }
 
 .detail-pane > .north {
-	overflow: hidden;
+	overflow: auto;
+	overflow-x: auto;
 }
 
 .detail-pane th {

--- a/duradmin/src/main/webapp/style/base.css
+++ b/duradmin/src/main/webapp/style/base.css
@@ -653,7 +653,8 @@ input.dc-check-all
 }
 
 .detail-pane > .north {
-	overflow: hidden;
+	overflow: auto;
+	overflow-x: auto;
 }
 
 .detail-pane th {
@@ -1266,7 +1267,7 @@ table.dc-acls td:last-child {
 }
 
 .button-bar {
-	white-space: normal;
+	white-space: nowrap;
 }
 
 .object-name {

--- a/duradmin/src/main/webapp/style/base.css
+++ b/duradmin/src/main/webapp/style/base.css
@@ -653,8 +653,7 @@ input.dc-check-all
 }
 
 .detail-pane > .north {
-	overflow: auto;
-	overflow-x: auto;
+	overflow: hidden;
 }
 
 .detail-pane th {
@@ -1267,7 +1266,7 @@ table.dc-acls td:last-child {
 }
 
 .button-bar {
-	white-space: nowrap;
+	white-space: normal;
 }
 
 .object-name {


### PR DESCRIPTION
…aller screens

**Adds vertical and horizontal scrollbars so that text and buttons are accessible in smaller screens, adds space at the bottom of the pane for the horizontal scrollbar**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-680

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR adds vertical and horizontal scrollbars to the details pane so that they're accessible in smaller screens.

# How should this be tested?
Deploy Duracloud, log in, and then shrink the browser window. The details pane in the upper right corner will include scrollbars that allow you to find the buttons.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
