### PR TITLE
Ensures that storage  provider options are passed to the chronopolis …

### DIFF
--- a/durastore/src/main/java/org/duracloud/durastore/util/StorageProviderFactoryImpl.java
+++ b/durastore/src/main/java/org/duracloud/durastore/util/StorageProviderFactoryImpl.java
@@ -219,7 +219,7 @@ public class StorageProviderFactoryImpl extends ProviderFactoryBase
                                                        password,
                                                        account.getOptions());
         } else if (type.equals(StorageProviderType.CHRONOPOLIS)) {
-            storageProvider = new ChronopolisStorageProvider(username, password);
+            storageProvider = new ChronopolisStorageProvider(username, password, account.getOptions());
         } else if (type.equals(StorageProviderType.TEST_RETRY)) {
             storageProvider = new MockRetryStorageProvider();
         } else if (type.equals(StorageProviderType.TEST_VERIFY_CREATE)) {

--- a/durastore/src/main/java/org/duracloud/durastore/util/TaskProviderFactoryImpl.java
+++ b/durastore/src/main/java/org/duracloud/durastore/util/TaskProviderFactoryImpl.java
@@ -114,7 +114,7 @@ public class TaskProviderFactoryImpl extends ProviderFactoryBase
                                                    storageAccountId);
         } else if (type.equals(StorageProviderType.CHRONOPOLIS)) {
             SnapshotStorageProvider unwrappedSnapshotProvider =
-                new ChronopolisStorageProvider(username, password);
+                new ChronopolisStorageProvider(username, password, account.getOptions());
             AmazonS3 s3Client =
                 S3ProviderUtil.getAmazonS3Client(username, password, account.getOptions());
 

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshotstorage/ChronopolisStorageProvider.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshotstorage/ChronopolisStorageProvider.java
@@ -26,10 +26,6 @@ public class ChronopolisStorageProvider extends SnapshotStorageProvider {
     private final Logger log =
         LoggerFactory.getLogger(ChronopolisStorageProvider.class);
 
-    public ChronopolisStorageProvider(String accessKey, String secretKey) {
-        super(accessKey, secretKey);
-    }
-
     public ChronopolisStorageProvider(String accessKey, String secretKey,
                                       Map<String, String> options) {
         super(accessKey, secretKey, options);

--- a/snapshotstorageprovider/src/test/java/org/duracloud/snapshotstorage/ChronopolisStorageProviderTest.java
+++ b/snapshotstorageprovider/src/test/java/org/duracloud/snapshotstorage/ChronopolisStorageProviderTest.java
@@ -9,6 +9,8 @@ package org.duracloud.snapshotstorage;
 
 import static org.junit.Assert.assertEquals;
 
+import java.util.HashMap;
+
 import org.duracloud.storage.domain.StorageProviderType;
 import org.junit.Test;
 
@@ -21,7 +23,7 @@ public class ChronopolisStorageProviderTest {
     @Test
     public void testGetStorageProviderType() {
         ChronopolisStorageProvider provider =
-            new ChronopolisStorageProvider("accessKey", "secretKey");
+            new ChronopolisStorageProvider("accessKey", "secretKey", new HashMap<>() );
         assertEquals(StorageProviderType.CHRONOPOLIS, provider.getStorageProviderType());
     }
 


### PR DESCRIPTION
…storage provider.

**JIRA Ticket**:  https://jira.duraspace.org/browse/DURACLOUD-1234

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Removes the ChronopolisStorageProvider constructor that allows one to pass no options since it should not be used anywhere in the code at this point.
# How should this be tested?

Go to https://danny.d.o to verify that the chronopolis storage provider returns the space and snapshot listings.  Verify that the error messages in the logs (mentioned in the jira issue above) are not longer appearing.
# Interested parties
@bbranan 