### PR TITLE
duracloud-1155 and duracloud-1154: Post update chunk clean up

### DIFF
--- a/synctool/content/my-file.txt
+++ b/synctool/content/my-file.txt
@@ -1,1 +1,0 @@
-hello world

--- a/synctool/content/my-file.txt
+++ b/synctool/content/my-file.txt
@@ -1,0 +1,1 @@
+hello world

--- a/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpoint.java
+++ b/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpoint.java
@@ -7,9 +7,9 @@
  */
 package org.duracloud.sync.endpoint;
 
+import static java.text.MessageFormat.format;
 import static org.duracloud.chunk.manifest.ChunksManifest.manifestSuffix;
 
-import java.text.MessageFormat;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -22,6 +22,8 @@ import org.duracloud.chunk.manifest.ChunksManifestBean;
 import org.duracloud.chunk.util.ChunksManifestVerifier;
 import org.duracloud.chunk.writer.DuracloudContentWriter;
 import org.duracloud.client.ContentStore;
+import org.duracloud.common.retry.Retriable;
+import org.duracloud.common.retry.Retrier;
 import org.duracloud.domain.Content;
 import org.duracloud.error.ContentStoreException;
 import org.duracloud.stitch.FileStitcher;
@@ -211,57 +213,70 @@ public class DuraStoreChunkSyncEndpoint extends DuraStoreSyncEndpoint {
                            syncFile.getStream(),
                            properties);
 
+        cleanup(contentId, syncFile, store, spaceId);
+
+    }
+
+    private void cleanup(final String contentId, final MonitoredFile syncFile, final ContentStore store, final String spaceId) {
         //clean up any orphaned chunks and / or obsolete unchunked files
         try {
-            log.debug("checking for chunks, manifests, and/or unchunked files that should be removed : for {}/{}",
-                      spaceId, contentId);
-            Iterator<String> chunkedContentIdIt = store.getSpaceContents(getSpaceId(), contentId + ".dura-");
-            Set<String> chunkedContentIds = new HashSet<>();
-            chunkedContentIdIt.forEachRemaining(id -> chunkedContentIds.add(id));
-            //if there are chunks
-            if (!chunkedContentIds.isEmpty()) {
-                //clean up
-                if (syncFile.length() <= chunkerOptions.getMaxChunkSize()) {
-                    log.info("A chunked version was replaced by an unchunked version of {}/{}",
+            new Retrier().execute(new Retriable() {
+                @Override
+                public Object retry() throws Exception {
+                    log.debug("checking for chunks, manifests, and/or unchunked files that should be removed : for {}/{}",
                               spaceId, contentId);
+                    Iterator<String> chunkedContentIdIt = store.getSpaceContents(getSpaceId(), contentId + ".dura-");
+                    Set<String> chunkedContentIds = new HashSet<>();
+                    chunkedContentIdIt.forEachRemaining(id -> chunkedContentIds.add(id));
+                    //if there are chunks
+                    if (!chunkedContentIds.isEmpty()) {
+                        //clean up
+                        if (syncFile.length() <= chunkerOptions.getMaxChunkSize()) {
+                            log.info("A chunked version was replaced by an unchunked version of {}/{}",
+                                     spaceId, contentId);
 
-                    //if file is less than or equal to max chunk size
-                    //then we can expect the new file is unchunked
-                    //look for any chunked content matching path
-                    //delete all.
-                    chunkedContentIds.stream().forEach(content -> {
-                        deleteContent(spaceId, content, store);
-                    });
-                    log.info("Deleted manifest and all chunks associated with {}/{} due " +
-                             "because the chunked file was replaced by an unchunked file with " +
-                             "the same name.",
-                              spaceId, contentId);
-                } else {
-                    log.debug("Checking for orphaned chunks associated with {}/{}",
-                             spaceId, contentId);
+                            //if file is less than or equal to max chunk size
+                            //then we can expect the new file is unchunked
+                            //look for any chunked content matching path
+                            //delete all.
+                            chunkedContentIds.stream().forEach(content -> {
+                                deleteContent(spaceId, content, store);
+                            });
+                            log.info("Deleted manifest and all chunks associated with {}/{} due " +
+                                     "because the chunked file was replaced by an unchunked file with " +
+                                     "the same name.",
+                                     spaceId, contentId);
+                        } else {
+                            log.debug("Checking for orphaned chunks associated with {}/{}",
+                                      spaceId, contentId);
 
-                    //resolve the set of the chunks in the manifest
-                    ChunksManifest manifest = getManifest(spaceId, contentId);
-                    Set<String> manifestChunks = new HashSet<>();
-                    manifest.getEntries().stream().forEach(entry -> manifestChunks.add(entry.getChunkId()));
-                    //for each chunk in storage, delete if not in the manifest.
-                    chunkedContentIds.stream()
-                                     .filter(chunkedContentId -> !chunkedContentId.endsWith(manifestSuffix))
-                                     .forEach(chunk -> {
-                                         if (!manifestChunks.contains(chunk)) {
-                                             log.debug("Chunk not found in manifest: deleting orphaned chunk ({}/{})",
-                                                       spaceId, chunk);
-                                             deleteContent(spaceId, chunk, store);
-                                         }
-                                     });
-                    //check for an unchunked version and remove it if happens to exist.
-                    if (store.contentExists(spaceId, contentId)) {
-                        deleteContent(spaceId, contentId, store);
+                            //resolve the set of the chunks in the manifest
+                            ChunksManifest manifest = getManifest(spaceId, contentId);
+                            Set<String> manifestChunks = new HashSet<>();
+                            manifest.getEntries().stream().forEach(entry -> manifestChunks.add(entry.getChunkId()));
+                            //for each chunk in storage, delete if not in the manifest.
+                            chunkedContentIds.stream()
+                                             .filter(chunkedContentId -> !chunkedContentId.endsWith(manifestSuffix))
+                                             .forEach(chunk -> {
+                                                 if (!manifestChunks.contains(chunk)) {
+                                                     log.debug("Chunk not found in manifest: deleting orphaned chunk ({}/{})",
+                                                               spaceId, chunk);
+                                                     deleteContent(spaceId, chunk, store);
+                                                 }
+                                             });
+                            //check for an unchunked version and remove it if happens to exist.
+                            if (store.contentExists(spaceId, contentId)) {
+                                deleteContent(spaceId, contentId, store);
+                            }
+                        }
                     }
+
+                    return null;
                 }
-            }
+            });
         } catch (Exception ex) {
-            throw new RuntimeException(ex);
+            log.error(format("Cleanup failed for  ({0}/{1})",
+                             spaceId, contentId), ex);
         }
     }
 
@@ -270,7 +285,7 @@ public class DuraStoreChunkSyncEndpoint extends DuraStoreSyncEndpoint {
             store.deleteContent(spaceId, contentId);
             log.debug("Deleted content  ({}/{})", spaceId, contentId);
         } catch (Exception ex) {
-            final String message = MessageFormat.format(
+            final String message = format(
                 "Failed to delete content ({0}/{1}) due to {2}. As this is a non-critical failure, processing will " +
                  "continue on.", spaceId, contentId, ex.getMessage());
             log.error(message, ex);

--- a/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpoint.java
+++ b/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpoint.java
@@ -7,8 +7,13 @@
  */
 package org.duracloud.sync.endpoint;
 
+import static org.duracloud.chunk.manifest.ChunksManifest.manifestSuffix;
+
+import java.text.MessageFormat;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import org.duracloud.chunk.FileChunker;
 import org.duracloud.chunk.FileChunkerOptions;
@@ -144,7 +149,7 @@ public class DuraStoreChunkSyncEndpoint extends DuraStoreSyncEndpoint {
     }
 
     protected String getManifestId(String contentId) {
-        String manifestId = contentId + ChunksManifest.manifestSuffix;
+        String manifestId = contentId + manifestSuffix;
         return manifestId;
     }
 
@@ -193,16 +198,81 @@ public class DuraStoreChunkSyncEndpoint extends DuraStoreSyncEndpoint {
     protected void addUpdateContent(String contentId,
                                     MonitoredFile syncFile) {
         Map<String, String> properties = createProps(syncFile.getAbsolutePath(), getUsername());
-        DuracloudContentWriter contentWriter =
-            new DuracloudContentWriter(getContentStore(), getUsername(), true, this.jumpStart);
-        FileChunker chunker = new FileChunker(contentWriter, chunkerOptions);
+        final ContentStore store = getContentStore();
 
-        chunker.addContent(getSpaceId(),
+        DuracloudContentWriter contentWriter =
+            new DuracloudContentWriter(store, getUsername(), true, this.jumpStart);
+        FileChunker chunker = new FileChunker(contentWriter, chunkerOptions);
+        final String spaceId = getSpaceId();
+        chunker.addContent(spaceId,
                            contentId,
                            syncFile.getChecksum(),
                            syncFile.length(),
                            syncFile.getStream(),
                            properties);
+
+        //clean up any orphaned chunks and / or obsolete unchunked files
+        try {
+            log.debug("checking for chunks, manifests, and/or unchunked files that should be removed : for {}/{}",
+                      spaceId, contentId);
+            Iterator<String> chunkedContentIdIt = store.getSpaceContents(getSpaceId(), contentId + ".dura-");
+            Set<String> chunkedContentIds = new HashSet<>();
+            chunkedContentIdIt.forEachRemaining(id -> chunkedContentIds.add(id));
+            //if there are chunks
+            if (!chunkedContentIds.isEmpty()) {
+                //clean up
+                if (syncFile.length() <= chunkerOptions.getMaxChunkSize()) {
+                    log.info("A chunked version was replaced by an unchunked version of {}/{}",
+                              spaceId, contentId);
+
+                    //if file is less than or equal to max chunk size
+                    //then we can expect the new file is unchunked
+                    //look for any chunked content matching path
+                    //delete all.
+                    chunkedContentIds.stream().forEach(content -> {
+                        deleteContent(spaceId, content, store);
+                    });
+                    log.info("Deleted manifest and all chunks associated with {}/{}",
+                              spaceId, contentId);
+                } else {
+                    log.info("Checking for orphaned chunks associated with {}/{}",
+                             spaceId, contentId);
+
+                    //resolve the set of the chunks in the manifest
+                    ChunksManifest manifest = getManifest(spaceId, contentId);
+                    Set<String> manifestChunks = new HashSet<>();
+                    manifest.getEntries().stream().forEach(entry -> manifestChunks.add(entry.getChunkId()));
+                    //for each chunk in storage, delete if not in the manifest.
+                    chunkedContentIds.stream()
+                                     .filter(chunkedContentId -> !chunkedContentId.endsWith(manifestSuffix))
+                                     .forEach(chunk -> {
+                                         if (!manifestChunks.contains(chunk)) {
+                                             log.debug("Chunk not found in manifest: deleting orphaned chunk ({}/{})",
+                                                       spaceId, chunk);
+                                             deleteContent(spaceId, chunk, store);
+                                         }
+                                     });
+                    //check for an unchunked version and remove it if happens to exist.
+                    if (store.contentExists(spaceId, contentId)) {
+                        deleteContent(spaceId, contentId, store);
+                    }
+                }
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private void deleteContent(String spaceId, String contentId, ContentStore store) {
+        try {
+            store.deleteContent(spaceId, contentId);
+            log.info("Deleted content  ({}/{})", spaceId, contentId);
+        } catch (Exception ex) {
+            final String message = MessageFormat.format(
+                "Failed to delete content ({0}/{1}) due to {2}. As this is a non-critical failure, processing will " +
+                 "continue on.", spaceId, contentId, ex.getMessage());
+            log.error(message, ex);
+        }
     }
 
     @Override

--- a/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpoint.java
+++ b/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpoint.java
@@ -232,10 +232,12 @@ public class DuraStoreChunkSyncEndpoint extends DuraStoreSyncEndpoint {
                     chunkedContentIds.stream().forEach(content -> {
                         deleteContent(spaceId, content, store);
                     });
-                    log.info("Deleted manifest and all chunks associated with {}/{}",
+                    log.info("Deleted manifest and all chunks associated with {}/{} due " +
+                             "because the chunked file was replaced by an unchunked file with " +
+                             "the same name.",
                               spaceId, contentId);
                 } else {
-                    log.info("Checking for orphaned chunks associated with {}/{}",
+                    log.debug("Checking for orphaned chunks associated with {}/{}",
                              spaceId, contentId);
 
                     //resolve the set of the chunks in the manifest
@@ -266,7 +268,7 @@ public class DuraStoreChunkSyncEndpoint extends DuraStoreSyncEndpoint {
     private void deleteContent(String spaceId, String contentId, ContentStore store) {
         try {
             store.deleteContent(spaceId, contentId);
-            log.info("Deleted content  ({}/{})", spaceId, contentId);
+            log.debug("Deleted content  ({}/{})", spaceId, contentId);
         } catch (Exception ex) {
             final String message = MessageFormat.format(
                 "Failed to delete content ({0}/{1}) due to {2}. As this is a non-critical failure, processing will " +

--- a/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpoint.java
+++ b/synctool/src/main/java/org/duracloud/sync/endpoint/DuraStoreChunkSyncEndpoint.java
@@ -241,7 +241,7 @@ public class DuraStoreChunkSyncEndpoint extends DuraStoreSyncEndpoint {
                         chunkedContentIds.stream().forEach(content -> {
                             deleteContent(spaceId, content, store);
                         });
-                        log.info("Deleted manifest and all chunks associated with {}/{} due " +
+                        log.info("Deleted manifest and all chunks associated with {}/{} " +
                                  "because the chunked file was replaced by an unchunked file with " +
                                  "the same name.",
                                  spaceId, contentId);


### PR DESCRIPTION
**Post update chunk clean up**
* * *
**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1154 and https://jira.duraspace.org/browse/DURACLOUD-1155
* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This commit ensures that chunked and unchunked content is clean up after an update in the following cases:

1) When replacing a chunked file with another chunked file with fewer chunks, the orphaned chunks are now removed.
2) Whn replacing a chunked file with an unchunked file,  the chunked file is removed.
3) When replacing an unchunked file with an chunked file, the unchunked file is removed.

# How should this be tested?

1. upload a 1K unchunked file (fileA) to space (spaceA)
2. create a 1025 MB file named fileA and sync to duracloud using the sync tool.
3. verify that the unchunked fileA is gone and the chunked file remains.
4. copy the 1K fileA into your sync tool content directory 
5. verify that fileA exists in duracloud and all chunks are removed.
6. remove fileA from duracloud
7. upload via the ui the following 4 files (they can be any size):
      fileA.dura-manifest
      fileA.dura-chunk-0000
      fileA.dura-chunk-0001
      fileA.dura-chunk-0002
8. create a 1025 MB file named fileA and sync to duracloud 
9  verify that only  fileA.dura-manifest, fileA.dura-chunk-0000, and fileA.dura-chunk-0001 remain.
     
# Interested parties
@bbranan 