### PR TITLE
Duracloud 1192: changes to space deletion process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8

--- a/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
+++ b/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
@@ -170,10 +170,17 @@
                   value=""
                   placeholder="filter"
                   type="text" />
-                </span> <input
+                </span>
+                <sec:authorize access="hasRole('ROLE_ROOT')">
+                  <c:set var="rootUser" value="rootUser" />
+                </sec:authorize>
+                <c:if test="${not empty rootUser}">
+                  <input
                   id="check-all-spaces"
                   class="dc-check-all"
-                  type="checkbox" /> <span
+                  type="checkbox" />
+                </c:if>
+                <span
                   id="space-list-status"
                   class="dc-status"
                   style="display: none"></span>
@@ -635,9 +642,6 @@
               type="hidden"
               name="storeId"
               id="storeId" />
-            <sec:authorize access="hasRole('ROLE_ROOT')">
-              <c:set var="rootUser" value="rootUser" />
-            </sec:authorize>
             <c:if test="${fn:length(contentStores) == 1 or empty rootUser}">
               <input
                 type="hidden"

--- a/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
+++ b/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
@@ -508,7 +508,7 @@
           style="display: none">
           <h1>Delete Space</h1>
           <div class="hint">
-            <h2>Choosing to DELETE the space named <div id="spaceId" style="display: inline-block;font-weight: bold;"></div> will remove all files in the space. THIS ACTION CANNOT BE UNDONE!</h2>
+            <h2>Choosing to DELETE the space named <div id="spaceId" style="display: inline-block;font-weight: bold;"></div> will remove <div id="spaceItemCount" style="display: inline-block;font-weight: bold;"></div> file(s) in the space. THIS ACTION CANNOT BE UNDONE!</h2>
             <br/><br/>
             <h2>Please type the name of the space below.</h2>
           </div>

--- a/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
+++ b/duradmin/src/main/webapp/WEB-INF/jsp/spaces/spaces-manager.jsp
@@ -502,6 +502,37 @@
         </div>
 
         <div
+          id="delete-space-dialog"
+          class=""
+          title="Delete Space"
+          style="display: none">
+          <h1>Delete Space</h1>
+          <div class="hint">
+            <h2>Choosing to DELETE the space named <div id="spaceId" style="display: inline-block;font-weight: bold;"></div> will remove all files in the space. THIS ACTION CANNOT BE UNDONE!</h2>
+            <br/><br/>
+            <h2>Please type the name of the space below.</h2>
+          </div>
+          <form id="delete-space-form">
+            <input type="hidden" name="compareSpaceId" id="compareSpaceId" class="field" />
+            <div
+              id="form-fields"
+              class="form-fields">
+              <fieldset>
+                <ul>
+                  <li class="row clearfix first-of-type"><label
+                    for="spacename">Space Name</label><input
+                    type="text"
+                    name="spaceId"
+                    id="spaceId"
+                    class="field" />
+                  </li>
+                </ul>
+              </fieldset>
+            </div>
+          </form>
+        </div>
+
+        <div
           id="add-content-item-dialog"
           class="dialog"
           title="Add Content Item"

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -3288,6 +3288,7 @@ $(function() {
       this._deleteSpaceDialog = $("#delete-space-dialog");
 
       this._deleteSpaceDialog.find("#spaceId").text(space.spaceId ? space.spaceId : "");
+      this._deleteSpaceDialog.find("#spaceItemCount").text((space.itemCount > 0) ? space.itemCount : "0");
       this._deleteSpaceDialog.find("input[name=compareSpaceId]").val(space.spaceId ? space.spaceId : "");
 
       this._deleteSpaceDialog.dialog({

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -2996,9 +2996,12 @@ $(function() {
     _initPane : function() {
       var that = this;
 
-      // attach delete button listener
+      // remove the single space delete handler
       var deleteButton = $(".delete-space-button", this.element);
-      deleteButton.unbind().click(function(evt) {
+      deleteButton.die("click.single");
+
+      // attach delete button listener
+      deleteButton.unbind().live("click.multi", function(evt) {
         var confirmText = "Are you sure you want to delete multiple spaces?";
         var busyText = "Deleting spaces";
         var spaces = that._spaces;
@@ -3353,8 +3356,12 @@ $(function() {
         }
       });
 
+      // remove the multi space delete handler
+      var deleteButton = $(".delete-space-button", this.element);
+      deleteButton.die("click.multi");
+
       // launcher
-      $('.delete-space-button', this.element).live("click", function(evt) {
+      $('.delete-space-button', this.element).live("click.single", function(evt) {
         that._deleteSpaceDialog.dialog("open");
       });
 

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -1438,9 +1438,15 @@ $(function() {
     _initSpacesList : function() {
       var that = this;
       this._spacesList = $("#spaces-list", this.element);
-      this._spacesList.selectablelist({
-        selectable : true
-      });
+      if (this._isRoot()) {
+        this._spacesList.selectablelist({
+            selectable : true
+        });
+      } else {
+        this._spacesList.selectablelist({
+            selectable : false
+        });
+      }
 
       this._spacesList.bind("currentItemChanged", function(evt, state) {
         that._handleSpaceListStateChangedEvent(evt, state);


### PR DESCRIPTION
**Adds limits to space deletion process so that only root users can select multiple spaces, and all users must type in the name of the space to delete it.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1192

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR makes the following changes: 1) limits selecting multiple spaces simultaneously for deletion to root users and 2) adds a dialog window to the deletion process that warns users of the severity of their actions and requires them to type in the name of the space they want to delete before deleting it.

# How should this be tested?
- Deploy Duracloud and log in as a root user and then as a non-root users. Verify that multiple spaces can only be selected in the case of the former. Then select a space and click the delete button and test that the dialog form makes you correctly type in the space name in order to delete it.

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? Maybe
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
