### PR TITLE
DURACLOUD-1243: Specifies Ubuntu 14.04 Trusty as Travis build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1243

# What does this Pull Request do?

Specifies Ubuntu 14.04 Trusty as the required Travis build environment. The Trusty environment is required because it supports Oracle Java 8 whereas Ubuntu 16.04 Xenial does not.

# How should this be tested?

If the CI build passes we should be good to go.