### PR TITLE
Duracloud 1237: moves streaming panel to the bottom of panels and restricts display to the S3 storage provider

### DIFF
--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -3214,10 +3214,6 @@ $(function() {
           makePublicButton.hide();
         }
 
-        if( space.primaryStorageProvider && this._isAdmin() && !this._isSnapshot(this._storeId)){
-            this._loadStreamingPane(space);
-        }
-
         this._loadSnapshotPane(space);
 
         this._loadRestorePane(space);
@@ -3238,6 +3234,12 @@ $(function() {
       }
 
       this._loadHistoryPanel(space);
+
+      if (this._isAdmin()) {
+        if (space.primaryStorageProvider && this._isS3(space.storeId) && this._isAdmin() && !this._isSnapshot(this._storeId)) {
+            this._loadStreamingPane(space);
+        }
+      }
     },
 
     _getRestoreId : function(space) {
@@ -3288,6 +3290,16 @@ $(function() {
       });
     },
 
+   _isS3 : function(storeId) {
+      var iss3 = false;
+      $.each(storeProviders, function(i, provider) {
+        if (storeId == provider.id && provider.type == 'amazon_s3') {
+          iss3 = true;
+          return false;
+        }
+      });
+      return iss3;
+    },
   }));
 
   /**

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -297,6 +297,17 @@ $(function() {
       return ischron;
     },
 
+   _isS3 : function(storeId) {
+      var iss3 = false;
+      $.each(storeProviders, function(i, provider) {
+        if (storeId == provider.id && provider.type == 'amazon_s3') {
+          iss3 = true;
+          return false;
+        }
+      });
+      return iss3;
+    },
+
     _isObjectAlreadyDisplayedInDetail : function(objectId) {
       return (this._storeId + "/" + objectId == $("#detail-pane .object-id").html());
     },
@@ -3235,10 +3246,8 @@ $(function() {
 
       this._loadHistoryPanel(space);
 
-      if (this._isAdmin()) {
-        if (space.primaryStorageProvider && this._isS3(space.storeId) && this._isAdmin() && !this._isSnapshot(this._storeId)) {
-            this._loadStreamingPane(space);
-        }
+      if (this._isAdmin() && this._isS3(space.storeId)) {
+        this._loadStreamingPane(space);
       }
     },
 
@@ -3288,17 +3297,6 @@ $(function() {
           alert("failed to delete space!");
         },
       });
-    },
-
-   _isS3 : function(storeId) {
-      var iss3 = false;
-      $.each(storeProviders, function(i, provider) {
-        if (storeId == provider.id && provider.type == 'amazon_s3') {
-          iss3 = true;
-          return false;
-        }
-      });
-      return iss3;
     },
   }));
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1237

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Moves the streaming panel to the bottom of panels and restricts its display to the S3 storage provider.

# How should this be tested?
Deploy Duracloud and observe that the streaming panel only appears for S3 storage providers and has moved to the bottom of the display.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
