### PR TITLE
Duracloud-398: Disable cursor hot keys across all panes

### DIFF
--- a/duradmin/src/main/webapp/WEB-INF/jsp/layout/v2/base.jsp
+++ b/duradmin/src/main/webapp/WEB-INF/jsp/layout/v2/base.jsp
@@ -88,6 +88,7 @@
 			,	useStateCookie:		true
 			,   center__paneSelector: "#page-content"
 			,	center__onresize:	"centerLayout.resizeAll"
+			,   enableCursorHotkey: false
 		});
 	});	
 	</script>

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -718,7 +718,8 @@ $(function() {
       resizable : false,
       slidable : false,
       spacing_open : 0,
-      togglerLength_open : 0
+      togglerLength_open : 0,
+      enableCursorHotkey : false
     },
 
     _init : function() {
@@ -1372,9 +1373,9 @@ $(function() {
         north__slidable : false,
         north__spacing_open : 0,
         north__togglerLength_open : 0,
-        north__togglerLength_closed : 0
+        north__togglerLength_closed : 0,
+        enableCursorHotkey : false,
 
-        ,
         west__size : 800,
         west__minSize : 600,
         west__paneSelector : "#" + that._listBrowserId,
@@ -1388,6 +1389,7 @@ $(function() {
       });
 
       listBrowserLayout = $('#' + that._listBrowserId).layout({
+        enableCursorHotkey : false,
         west__size : 350,
         west__minSize : 260,
         west__paneSelector : "#" + that._spacesListViewId,
@@ -1411,7 +1413,8 @@ $(function() {
       resizable : false,
       slidable : false,
       spacing_open : 0,
-      togglerLength_open : 0
+      togglerLength_open : 0,
+      enableCursorHotkey : false
     },
 
     _spaces : [],
@@ -1644,7 +1647,8 @@ $(function() {
       resizable : false,
       slidable : false,
       spacing_open : 0,
-      togglerLength_open : 0
+      togglerLength_open : 0,
+      enableCursorHotkey : false
     },
     _spaceId : null,
     _init : function() {
@@ -2087,7 +2091,8 @@ $(function() {
       resizable : false,
       slidable : false,
       spacing_open : 0,
-      togglerLength_open : 0
+      togglerLength_open : 0,
+      enableCursorHotkey : false
     },
     _snapshot : null,
     _init : function() {
@@ -2333,8 +2338,8 @@ $(function() {
       resizable : false,
       slidable : false,
       spacing_open : 0,
-      togglerLength_open : 0
-
+      togglerLength_open : 0,
+      enableCursorHotkey : false
     },
 
     _init : function() {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-398

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Disables cursor hot keys in jQuery UI Layout panes, so that Shift + [arrow keys] doesn't do anything.

# How should this be tested?
Deploy Duracloud and try Shift + [arrow keys]. The UI should not change in random ways.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
