### PR TITLE
Duracloud 1203: Fixes 404 error when content ID contains forward slashes

### DIFF
--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -111,7 +111,10 @@ $(function() {
 
       var contentId = obj.contentId;
       if (contentId != null && contentId != undefined) {
-        relative += "/" + encodeURIComponent(contentId);
+        contentIdString = encodeURIComponent(contentId);
+        // Decode %2F back to forward slash for content IDs that are paths
+        contentIdString = contentIdString.replace(/%2F/gi, '/');
+        relative += "/" + contentIdString;
       }
       var snapshot = obj.snapshot;
       if (snapshot) {

--- a/resources/beanstalk/.ebextensions/elasticbeanstalk.conf
+++ b/resources/beanstalk/.ebextensions/elasticbeanstalk.conf
@@ -1,6 +1,7 @@
 <VirtualHost *:80>
   Timeout 300
   KeepAlive On
+  AllowEncodedSlashes On
 
   <Proxy *>
     Require all granted

--- a/resources/beanstalk/.ebextensions/elasticbeanstalk.conf
+++ b/resources/beanstalk/.ebextensions/elasticbeanstalk.conf
@@ -1,7 +1,7 @@
 <VirtualHost *:80>
   Timeout 300
   KeepAlive On
-  AllowEncodedSlashes On
+  AllowEncodedSlashes NoDecode
 
   <Proxy *>
     Require all granted


### PR DESCRIPTION
**Fixes 404 error when content ID contains forward slashes in two ways.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1203

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)
- Apache 2.4 config: http://httpd.apache.org/docs/2.4/mod/core.html#allowencodedslashes

# What does this Pull Request do?
There are two strategies included in this PR, and either of them fixes the problem by itself. I've included both to provide options and get the discussion started. The error is coming from Apache, and there is a configuration setting that allows for the %2F encoding. If there are security issues with that then the slashes can be decoded separate from the other special characters. 

# How should this be tested?
Deploy Duracloud, select a content item with a forward slash in the ID. Hit the refresh button in the GUI and the refresh button in the browser. Notice that the page successfully reloads.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? Probably not.
* Could this change impact execution of existing code? No

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
