### PR TITLE
DURACLOUD-1245 - Allows retry calls to create space to respond with a 201

### DIFF
--- a/durastore/src/main/java/org/duracloud/durastore/rest/SpaceResource.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/SpaceResource.java
@@ -16,6 +16,7 @@ import org.duracloud.durastore.error.ResourceException;
 import org.duracloud.durastore.error.ResourceNotFoundException;
 import org.duracloud.storage.error.InvalidIdException;
 import org.duracloud.storage.error.NotFoundException;
+import org.duracloud.storage.error.SpaceAlreadyExistsException;
 import org.duracloud.storage.error.StorageException;
 import org.duracloud.storage.provider.StorageProvider;
 import org.duracloud.storage.util.IdUtil;
@@ -173,6 +174,8 @@ public class SpaceResource {
 
             waitForSpaceCreation(storage, spaceID);
             updateSpaceACLs(spaceID, userACLs, storeID);
+        } catch (SpaceAlreadyExistsException e) {
+            throw e;
         } catch (NotFoundException e) {
             throw new InvalidIdException(e.getMessage());
         } catch (Exception e) {

--- a/durastore/src/main/java/org/duracloud/durastore/rest/SpaceRest.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/SpaceRest.java
@@ -34,6 +34,7 @@ import org.duracloud.durastore.error.ResourceException;
 import org.duracloud.durastore.error.ResourceNotFoundException;
 import org.duracloud.security.context.SecurityContextUtil;
 import org.duracloud.storage.error.InvalidIdException;
+import org.duracloud.storage.error.SpaceAlreadyExistsException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -258,9 +259,14 @@ public class SpaceRest extends BaseRest {
         throws ResourceException, InvalidIdException {
         Map<String, AclType> userACLs = getUserACLs();
 
-        spaceResource.addSpace(spaceID,
-                               userACLs,
-                               storeID);
+        try {
+            spaceResource.addSpace(spaceID,
+                                   userACLs,
+                                   storeID);
+        } catch (SpaceAlreadyExistsException e) {
+            log.info("Create space called on " + spaceID +
+                     " but space already exists. Space setup skipped.");
+        }
         URI location = uriInfo.getRequestUri();
         return Response.created(location).build();
     }

--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
@@ -327,13 +327,13 @@ public class S3StorageProvider extends StorageProviderBase {
     public void setSpaceLifecycle(String bucketName,
                                   BucketLifecycleConfiguration config) {
         boolean success = false;
-        int maxLoops = 6;
+        int maxLoops = 8;
         for (int loops = 0; !success && loops < maxLoops; loops++) {
             try {
                 s3Client.deleteBucketLifecycleConfiguration(bucketName);
                 s3Client.setBucketLifecycleConfiguration(bucketName, config);
                 success = true;
-            } catch (NotFoundException e) {
+            } catch (NotFoundException | AmazonS3Exception e) {
                 success = false;
                 wait(loops);
             }
@@ -342,7 +342,7 @@ public class S3StorageProvider extends StorageProviderBase {
         if (!success) {
             throw new StorageException(
                 "Lifecycle policy for bucket " + bucketName +
-                " could not be applied. The space cannot be found.", RETRY);
+                " could not be applied. The space cannot be found.");
         }
     }
 
@@ -776,7 +776,7 @@ public class S3StorageProvider extends StorageProviderBase {
 
     protected void wait(int seconds) {
         try {
-            Thread.sleep(1000 * seconds);
+            Thread.sleep(2000 * seconds);
         } catch (InterruptedException e) {
             // End sleep on interruption
         }

--- a/storageprovider/src/main/java/org/duracloud/storage/error/SpaceAlreadyExistsException.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/error/SpaceAlreadyExistsException.java
@@ -1,0 +1,22 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.storage.error;
+
+/**
+ * Exception thrown on space creation if the space already exists
+ *
+ * @author Bill Branan
+ * Date: Oct 30, 2019
+ */
+public class SpaceAlreadyExistsException extends StorageException {
+
+    public SpaceAlreadyExistsException(String spaceId) {
+        super("Error: Space already exists: " + spaceId);
+    }
+
+}

--- a/storageprovider/src/main/java/org/duracloud/storage/provider/StorageProviderBase.java
+++ b/storageprovider/src/main/java/org/duracloud/storage/provider/StorageProviderBase.java
@@ -7,8 +7,6 @@
  */
 package org.duracloud.storage.provider;
 
-import static org.duracloud.storage.error.StorageException.NO_RETRY;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -251,13 +249,6 @@ public abstract class StorageProviderBase implements StorageProvider {
                 aclValues.append(aclValue).append(ACL_DELIM);
             }
             packedAcls.put(acl, aclValues.toString());
-        }
-    }
-
-    protected void throwIfSpaceExists(String spaceId) {
-        if (spaceExists(spaceId)) {
-            String msg = "Error: Space already exists: " + spaceId;
-            throw new StorageException(msg, NO_RETRY);
         }
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/DURACLOUD-1245

# What does this Pull Request do?

Calls to the Create Space endpoint that specified the name of an existing space used to generate 500 errors. This allows those same calls to get the same 201 response that the original call received but without making any changes to storage. This allows retries of space creation calls to complete successfully.

Retry logic is also added to a few S3 calls to reduce the potential for failure when performing those calls.

# How should this be tested?

* Perform multiple create space calls with the same parameters. The response should be the same each time. (201 with a Location header)

# Interested parties
@dbernstein @nwoodward 
