### PR TITLE
Duracloud 1247

### DIFF
--- a/resources/travis/before-install.sh
+++ b/resources/travis/before-install.sh
@@ -2,11 +2,13 @@
 echo 'Starting before-install.sh'
 if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = 'master' ] || [ "$TRAVIS_BRANCH" = 'develop' ]; then
     echo "Installing BitRock InstallBuilder"
-    wget https://dcprod.duracloud.org/durastore/resources/installbuilder-enterprise-17.12.0-linux-x64-installer.run
-    chmod +x installbuilder-enterprise-17.12.0-linux-x64-installer.run
+    installBuilderVersion = "19.12.0"
+    installBuilderInstaller = "installbuilder-enterprise-${installBuilderVersion}-linux-x64-installer.run"
+    wget https://dcprod.duracloud.org/durastore/resources/${installBuilderInstaller}
+    chmod +x ${installBuilderInstaller} 
     # Using sudo to ensure installbuilder is installed to /opt rather than under /home
-    sudo ./installbuilder-enterprise-17.12.0-linux-x64-installer.run --mode unattended
+    sudo ./${installBuilderInstaller} --mode unattended
     # Add license file
-    sudo openssl aes-256-cbc -K $encrypted_01c7144b0525_key -iv $encrypted_01c7144b0525_iv -in resources/travis/installbuilder-license.xml.enc -out /opt/installbuilder-17.12.0/license.xml -d
+    sudo openssl aes-256-cbc -K $encrypted_01c7144b0525_key -iv $encrypted_01c7144b0525_iv -in resources/travis/installbuilder-license.xml.enc -out /opt/installbuilder-${installBuilderVersion}/license.xml -d
     echo 'Completed before-install.sh'
 fi

--- a/resources/travis/mvndeploy-settings.xml
+++ b/resources/travis/mvndeploy-settings.xml
@@ -31,7 +31,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <installbuilder.executable.path>/opt/installbuilder-17.12.0/bin/builder</installbuilder.executable.path>
+        <installbuilder.executable.path>/opt/installbuilder-19.12.0/bin/builder</installbuilder.executable.path>
       </properties>
     </profile>
   </profiles>

--- a/synctoolui/pom.xml
+++ b/synctoolui/pom.xml
@@ -23,8 +23,7 @@
     <skipUTs>false</skipUTs>
     <jetty.port>8888</jetty.port>
     <durcloud.defaultport>443</durcloud.defaultport>
-    <installbuilder.executable.path>/Applications/BitRock InstallBuilder Enterprise
-      15.1.0/bin/Builder.app/Contents/MacOS/installbuilder.sh
+    <installbuilder.executable.path>/Applications/BitRock InstallBuilder Enterprise 19.12.0/bin/Builder.app/Contents/MacOS/installbuilder.sh
     </installbuilder.executable.path>
     <jre.unpack.dir>${project.build.directory}/jre</jre.unpack.dir>
   </properties>

--- a/synctoolui/src/main/install/installbuilder.xml
+++ b/synctoolui/src/main/install/installbuilder.xml
@@ -8,6 +8,7 @@
   <leftImage>${basedir}/src/main/install/duracloud-logo.png</leftImage>
   <splashImage>${basedir}/src/main/install/duracloud-logo.png</splashImage>
   <productDisplayIcon>${installdir}/duracloud-sync.ico</productDisplayIcon>
+  <osxPlatforms>osx-intel osx-x86_64</osxPlatforms>
   <componentList>
     <component>
       <name>default</name>


### PR DESCRIPTION
**Enables 64 bit builds of the macos installer **
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/DURACLOUD-1247

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# How should this be tested?
You'll need to install the latest install builder  (19.12.0) and update your  installbuilder.executable.path parameter (-D installbuilder.executable.path=...) when building the synctool.

`mvn clean install -Pinstallers  -D installbuilder.executable.path=...` 

Execute the installer on OSX 10.15 or greater

`open synctoolui/target/duracloudsync-6.2.0-SNAPSHOT-osx-installer.app`

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
