### PR TITLE
Handle headers case-insensitive

### DIFF
--- a/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/ContentStoreImpl.java
@@ -1089,16 +1089,16 @@ public class ContentStoreImpl implements ContentStore {
         for (Header header : response.getResponseHeaders()) {
             String name = header.getName();
             if (!name.startsWith(HEADER_PREFIX)) {
-                if (name.equals(HttpHeaders.CONTENT_TYPE)) {
+                if (name.equalsIgnoreCase(HttpHeaders.CONTENT_TYPE)) {
                     headers.put(CONTENT_MIMETYPE, header.getValue());
-                } else if (name.equals(HttpHeaders.CONTENT_MD5) ||
-                    name.equals(HttpHeaders.ETAG)) {
+                } else if (name.equalsIgnoreCase(HttpHeaders.CONTENT_MD5) ||
+                    name.equalsIgnoreCase(HttpHeaders.ETAG)) {
                     headers.put(CONTENT_CHECKSUM, header.getValue());
-                } else if (name.equals(HttpHeaders.CONTENT_LENGTH)) {
+                } else if (name.equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH)) {
                     headers.put(CONTENT_SIZE, header.getValue());
-                } else if (name.equals(HttpHeaders.LAST_MODIFIED)) {
+                } else if (name.equalsIgnoreCase(HttpHeaders.LAST_MODIFIED)) {
                     headers.put(CONTENT_MODIFIED, header.getValue());
-                } else if (name.equals(CONTENT_ENCODING)) {
+                } else if (name.equalsIgnoreCase(CONTENT_ENCODING)) {
                     headers.put(CONTENT_ENCODING, header.getValue());
                 }
             }
@@ -1345,13 +1345,13 @@ public class ContentStoreImpl implements ContentStore {
             new BitIntegrityReportProperties();
         for (Header header : response.getResponseHeaders()) {
             String name = header.getName();
-            if (name.equals(HttpHeaders.BIT_INTEGRITY_REPORT_RESULT)) {
+            if (name.equalsIgnoreCase(HttpHeaders.BIT_INTEGRITY_REPORT_RESULT)) {
                 properties.setResult(BitIntegrityReportResult.valueOf(header.getValue()));
-            } else if (name.equals(HttpHeaders.BIT_INTEGRITY_REPORT_COMPLETION_DATE)) {
+            } else if (name.equalsIgnoreCase(HttpHeaders.BIT_INTEGRITY_REPORT_COMPLETION_DATE)) {
                 SimpleDateFormat format =
                     new SimpleDateFormat(DateFormat.DEFAULT_FORMAT.getPattern());
                 properties.setCompletionDate(format.parse(header.getValue()));
-            } else if (name.equals(HttpHeaders.CONTENT_LENGTH)) {
+            } else if (name.equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH)) {
                 properties.setSize(Long.valueOf(header.getValue()));
             }
         }

--- a/storeclient/src/test/java/org/duracloud/client/ContentStoreImplTest.java
+++ b/storeclient/src/test/java/org/duracloud/client/ContentStoreImplTest.java
@@ -526,8 +526,8 @@ public class ContentStoreImplTest {
         String fullURL = baseURL + "/" + spaceId + "/" + contentId + "?storeID=" + storeId;
         EasyMock.expect(response.getStatusCode()).andReturn(200);
 
-        Header[] headers =
-            new Header[] {new BasicHeader("Content-Type", "text/xml"),
+        Header[] headers = // Using lower case header key to ensure case does not matter
+            new Header[] {new BasicHeader("content-type", "text/xml"),
                           new BasicHeader("x-dura-meta-custom-property", "custom")};
         EasyMock.expect(response.getResponseHeaders())
                 .andReturn(headers).times(2);


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/projects/DURACLOUD/issues/DURACLOUD-1252

# What does this Pull Request do?

In order to comply with HTTP standard RFC7230 we should handle all HTTP
headers in a case-insensitive manner.

This commit changes all instances where we are comparing headers to `equalsIgnoreCase()` instead of `equals()`.

# How should this be tested?

I changed one of the unit tests to use a lower case header, tests still pass.

We were having issues with missing elements in the UI when load balancing with HAProxy (HAProxy makes all headers lower case). This change has fixed all those issues.

# Interested parties
@bbranan 
