### PR TITLE
Update jackson 1.9 dependencies to defined jackson version

### DIFF
--- a/common-json/pom.xml
+++ b/common-json/pom.xml
@@ -29,13 +29,13 @@
 
     <!-- JAXB -->
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-xc</artifactId>
+      <groupId>com.fasterxml.jackson.module</groupId>
+      <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>
 
   </dependencies>

--- a/common-json/src/main/java/org/duracloud/common/json/JaxbJsonSerializer.java
+++ b/common-json/src/main/java/org/duracloud/common/json/JaxbJsonSerializer.java
@@ -10,10 +10,10 @@ package org.duracloud.common.json;
 import java.io.IOException;
 import java.io.StringWriter;
 
-import org.codehaus.jackson.map.AnnotationIntrospector;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
-import org.codehaus.jackson.xc.JaxbAnnotationIntrospector;
+import com.fasterxml.jackson.databind.AnnotationIntrospector;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 
 /**
  * Handles serialization and deserialization of objects JSON objects into
@@ -38,14 +38,14 @@ public class JaxbJsonSerializer<T> {
 
         // Create mapper
         mapper = new ObjectMapper();
-        mapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
 
         // Use JAX-B annotations
         AnnotationIntrospector introspector = new JaxbAnnotationIntrospector();
         mapper.getDeserializationConfig()
-              .withAnnotationIntrospector(introspector);
+              .withInsertedAnnotationIntrospector(introspector);
         mapper.getSerializationConfig()
-              .withAnnotationIntrospector(introspector);
+              .withInsertedAnnotationIntrospector(introspector);
     }
 
     public String serialize(T object) throws IOException {

--- a/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/SnapshotController.java
+++ b/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/SnapshotController.java
@@ -19,8 +19,8 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.http.HttpStatus;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import org.duracloud.client.ContentStore;
 import org.duracloud.client.ContentStoreManager;
 import org.duracloud.client.task.SnapshotTaskClient;

--- a/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/SnapshotController.java
+++ b/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/SnapshotController.java
@@ -18,9 +18,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 
-import org.apache.http.HttpStatus;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.http.HttpStatus;
 import org.duracloud.client.ContentStore;
 import org.duracloud.client.ContentStoreManager;
 import org.duracloud.client.task.SnapshotTaskClient;

--- a/duradmin/src/test/java/org/duracloud/duradmin/spaces/controller/SnapshotControllerTest.java
+++ b/duradmin/src/test/java/org/duracloud/duradmin/spaces/controller/SnapshotControllerTest.java
@@ -22,11 +22,11 @@ import java.util.Properties;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
-import org.apache.http.HttpStatus;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.http.HttpStatus;
 import org.duracloud.client.ContentStore;
 import org.duracloud.client.ContentStoreManager;
 import org.duracloud.client.task.SnapshotTaskClient;

--- a/duradmin/src/test/java/org/duracloud/duradmin/spaces/controller/SnapshotControllerTest.java
+++ b/duradmin/src/test/java/org/duracloud/duradmin/spaces/controller/SnapshotControllerTest.java
@@ -24,9 +24,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.apache.http.HttpStatus;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import org.duracloud.client.ContentStore;
 import org.duracloud.client.ContentStoreManager;
 import org.duracloud.client.task.SnapshotTaskClient;

--- a/durastore/src/main/java/org/duracloud/durastore/aop/SnapshotAccessAdvice.java
+++ b/durastore/src/main/java/org/duracloud/durastore/aop/SnapshotAccessAdvice.java
@@ -10,9 +10,9 @@ package org.duracloud.durastore.aop;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.duracloud.common.model.AclType;
 import org.duracloud.error.UnauthorizedException;
 import org.duracloud.security.util.AuthorizationHelper;

--- a/durastore/src/main/java/org/duracloud/durastore/aop/SnapshotAccessAdvice.java
+++ b/durastore/src/main/java/org/duracloud/durastore/aop/SnapshotAccessAdvice.java
@@ -10,8 +10,8 @@ package org.duracloud.durastore.aop;
 import java.lang.reflect.Method;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.duracloud.common.model.AclType;
 import org.duracloud.error.UnauthorizedException;

--- a/pom.xml
+++ b/pom.xml
@@ -1377,21 +1377,9 @@
       </dependency>
 
       <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-core-asl</artifactId>
-        <version>1.9.5</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-mapper-asl</artifactId>
-        <version>1.9.5</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.codehaus.jackson</groupId>
-        <artifactId>jackson-xc</artifactId>
-        <version>1.9.5</version>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This removes the older jackson dependencies which provided xml serialization/mapping utilities and pulls in the equivalent fasterxml dependency which uses the defined jackson version.

@bbranan 
