### PR TITLE
Backs out use of variables in Travis InstallBuilder installation script

### DIFF
--- a/resources/travis/before-install.sh
+++ b/resources/travis/before-install.sh
@@ -2,13 +2,11 @@
 echo 'Starting before-install.sh'
 if [ ! -z "$TRAVIS_TAG" ] || [ "$TRAVIS_BRANCH" = 'master' ] || [ "$TRAVIS_BRANCH" = 'develop' ]; then
     echo "Installing BitRock InstallBuilder"
-    installBuilderVersion = "19.12.0"
-    installBuilderInstaller = "installbuilder-enterprise-${installBuilderVersion}-linux-x64-installer.run"
-    wget https://dcprod.duracloud.org/durastore/resources/${installBuilderInstaller}
-    chmod +x ${installBuilderInstaller} 
+    wget https://dcprod.duracloud.org/durastore/resources/installbuilder-enterprise-19.12.0-linux-x64-installer.run
+    chmod +x installbuilder-enterprise-19.12.0-linux-x64-installer.run
     # Using sudo to ensure installbuilder is installed to /opt rather than under /home
-    sudo ./${installBuilderInstaller} --mode unattended
+    sudo ./installbuilder-enterprise-19.12.0-linux-x64-installer.run --mode unattended
     # Add license file
-    sudo openssl aes-256-cbc -K $encrypted_01c7144b0525_key -iv $encrypted_01c7144b0525_iv -in resources/travis/installbuilder-license.xml.enc -out /opt/installbuilder-${installBuilderVersion}/license.xml -d
+    sudo openssl aes-256-cbc -K $encrypted_01c7144b0525_key -iv $encrypted_01c7144b0525_iv -in resources/travis/installbuilder-license.xml.enc -out /opt/installbuilder-19.12.0/license.xml -d
     echo 'Completed before-install.sh'
 fi


### PR DESCRIPTION
In the 6.2.0 release, these variables were not read properly, causing the installers not to be created as part of the tag build in Travis CI.