### PR TITLE
DURACLOUD-1270: Update Jetty version 9.4.14 -> 9.4.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
     <tiles.version>2.2.2</tiles.version>
     <selenium.version>2.19.0</selenium.version>
     <slf4j.version>1.7.6</slf4j.version>
-    <jetty.version>9.4.14.v20181114</jetty.version>
+    <jetty.version>9.4.31.v20200723</jetty.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
**Update Jetty to latest minor release of version 9.4**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/DURACLOUD-1270

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Updates the Jetty Server to the latest minor version to improve performance and compatibility with newer versions of Java.

# How should this be tested?

Build the SyncTool and test syncing directories and files with a space in DuraCloud.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? No
* Does this change add any new dependencies? No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No
* Could this change impact execution of existing code? No

# Interested parties

@duracloud/committers
