### PR TITLE
Duracloud 1267: Provide feedback when content ID in a list file does not exist in the space

### DIFF
--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/CSVFileOutputWriter.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/CSVFileOutputWriter.java
@@ -28,6 +28,7 @@ public class CSVFileOutputWriter implements OutputWriter {
 
     protected static final String SUCCESS = "success";
     protected static final String FAILURE = "failure";
+    protected static final String MISSING = "missing";
     protected static final String OUTPUT_PREFIX = "retrieval-tool-output-";
 
     private PrintWriter writer;
@@ -81,6 +82,22 @@ public class CSVFileOutputWriter implements OutputWriter {
         result.append(quote(contentItem.getContentId())).append(",");
         result.append("none").append(",");
         result.append(quote(error)).append(",");
+        result.append(attempts).append(",");
+        result.append(DATE_FORMAT.format(new Date()));
+        writer.println(result.toString());
+        writer.flush();
+    }
+
+    @Override
+    public void writeMissing(ContentItem contentItem,
+                             String message,
+                             int attempts) {
+        StringBuilder result = new StringBuilder();
+        result.append(MISSING).append(",");
+        result.append(contentItem.getSpaceId()).append(",");
+        result.append(quote(contentItem.getContentId())).append(",");
+        result.append("none").append(",");
+        result.append(quote(message)).append(",");
         result.append(attempts).append(",");
         result.append(DATE_FORMAT.format(new Date()));
         writer.println(result.toString());

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/LoggingOutputWriter.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/LoggingOutputWriter.java
@@ -22,6 +22,7 @@ public class LoggingOutputWriter implements OutputWriter {
 
     protected static final String SUCCESS = "RETRIEVED";
     protected static final String FAILURE = "FAILED";
+    protected static final String MISSING = "MISSING";
 
     @Override
     public void writeSuccess(ContentItem contentItem, String localFilePath,
@@ -40,6 +41,13 @@ public class LoggingOutputWriter implements OutputWriter {
         log.info(format(new Object[] {
             FAILURE, contentItem.getSpaceId(), contentItem.getContentId(),
             "attempts:" + attempts, "error:" + error}));
+    }
+
+    @Override
+    public void writeMissing(ContentItem contentItem, String message, int attempts) {
+        log.info(format(new Object[] {
+            MISSING, contentItem.getSpaceId(), contentItem.getContentId(),
+            "attempts:" + attempts, "message:" + message}));
     }
 
     @Override

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/OutputWriter.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/OutputWriter.java
@@ -31,6 +31,10 @@ public interface OutputWriter {
                              String error,
                              int attempts);
 
+    public void writeMissing(ContentItem contentItem,
+                             String message,
+                             int attempts);
+
     public void close();
 
 }

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalWorker.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalWorker.java
@@ -30,6 +30,7 @@ import org.duracloud.common.util.ChecksumUtil;
 import org.duracloud.common.util.DateUtil;
 import org.duracloud.retrieval.source.ContentStream;
 import org.duracloud.retrieval.source.RetrievalSource;
+import org.duracloud.stitch.error.MissingContentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,6 +122,13 @@ public class RetrievalWorker implements Runnable {
                 props = retrieveToFile(localFile, listener);
                 succeed(localFile.getAbsolutePath());
             }
+        } catch (MissingContentException mce) {
+            logger.error("The remote file " +
+                         contentItem.getContentId() + " does not exist." +
+                         localFile.getAbsolutePath() + ": " + mce.getMessage(), mce);
+
+            missing(mce.getMessage());
+            throw mce;
         } catch (Throwable e) {
             logger.error("Exception retrieving remote file " +
                          contentItem.getContentId() + " as local file " +
@@ -236,6 +244,8 @@ public class RetrievalWorker implements Runnable {
             contentStream = new Retrier(5, 4000, 3).execute(() -> {
                 return source.getSourceContent(contentItem, listener);
             });
+        } catch (MissingContentException mce) {
+            throw mce;
         } catch (Exception ex) {
             throw new IOException(ex);
         }
@@ -343,4 +353,12 @@ public class RetrievalWorker implements Runnable {
         statusManager.failedCompletion();
     }
 
+    protected void missing(String msg) {
+        String message = "Unable to retrieve " + contentItem.toString() +
+                       " because it doesn't exist in the space.";
+        logger.warn(message);
+        System.err.println(message);
+        outWriter.writeMissing(contentItem, message, attempts);
+        statusManager.missingCompletion();
+    }
 }

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalWorker.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalWorker.java
@@ -123,10 +123,6 @@ public class RetrievalWorker implements Runnable {
                 succeed(localFile.getAbsolutePath());
             }
         } catch (MissingContentException mce) {
-            logger.error("The remote file " +
-                         contentItem.getContentId() + " does not exist." +
-                         localFile.getAbsolutePath() + ": " + mce.getMessage(), mce);
-
             missing(mce.getMessage());
             throw mce;
         } catch (Throwable e) {

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/StatusManager.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/StatusManager.java
@@ -26,6 +26,7 @@ public class StatusManager {
     private long noChange;
     private long succeeded;
     private long failed;
+    private long missing;
     private String startTime;
     private String version;
 
@@ -50,6 +51,7 @@ public class StatusManager {
         noChange = 0;
         succeeded = 0;
         failed = 0;
+        missing = 0;
         startTime = DATE_FORMAT.format(new Date());
     }
 
@@ -72,6 +74,11 @@ public class StatusManager {
         inWork--;
     }
 
+    public synchronized void missingCompletion() {
+        missing++;
+        inWork--;
+    }
+
     public long getInWork() {
         return inWork;
     }
@@ -87,6 +94,8 @@ public class StatusManager {
     public long getFailed() {
         return failed;
     }
+
+    public long getMissing() { return missing; }
 
     public void setVersion(String version) {
         this.version = version;
@@ -104,6 +113,7 @@ public class StatusManager {
         status.append("Successful Retrievals: " + getSucceeded() + "\n");
         status.append("No Change Needed: " + getNoChange() + "\n");
         status.append("Failed Retrievals: " + getFailed() + "\n");
+        status.append("Missing files: " + getMissing() + "\n");
         status.append("--------------------------------------\n");
         return status.toString();
     }

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/StatusManager.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/StatusManager.java
@@ -95,7 +95,9 @@ public class StatusManager {
         return failed;
     }
 
-    public long getMissing() { return missing; }
+    public long getMissing() {
+        return missing;
+    }
 
     public void setVersion(String version) {
         this.version = version;

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreRetrievalSource.java
@@ -19,6 +19,7 @@ import org.duracloud.common.model.ContentItem;
 import org.duracloud.domain.Content;
 import org.duracloud.error.ContentStoreException;
 import org.duracloud.retrieval.mgmt.RetrievalListener;
+import org.duracloud.stitch.error.MissingContentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreRetrievalSource.java
@@ -19,7 +19,6 @@ import org.duracloud.common.model.ContentItem;
 import org.duracloud.domain.Content;
 import org.duracloud.error.ContentStoreException;
 import org.duracloud.retrieval.mgmt.RetrievalListener;
-import org.duracloud.stitch.error.MissingContentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreSpecifiedRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreSpecifiedRetrievalSource.java
@@ -17,6 +17,7 @@ import org.duracloud.common.model.ContentItem;
 import org.duracloud.domain.Content;
 import org.duracloud.error.ContentStoreException;
 import org.duracloud.retrieval.mgmt.RetrievalListener;
+import org.duracloud.stitch.error.MissingContentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +70,7 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
         try {
             return contentStore.getContent(item.getSpaceId(),
                                            item.getContentId());
-        } catch (ContentStoreException e) {
+        } catch (ContentStoreException cse) {
             log.info("Error retrieving content ID: " + item.getContentId() +
                      ".  Trying to get this content again by checking for " +
                      "a chunk manifest for this content ID.");
@@ -77,7 +78,11 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
             // for the passed in ContentItem to this method.
             ContentItem manifestItem = new ContentItem(item.getSpaceId(),
                                                        item.getContentId() + ChunksManifest.manifestSuffix);
-            return doGetContentFromManifest(manifestItem, listener);
+            try {
+                return doGetContentFromManifest(manifestItem, listener);
+            } catch (MissingContentException mse) {
+                throw mse;
+            }
         }
     }
 }

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreStitchingRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreStitchingRetrievalSource.java
@@ -88,6 +88,7 @@ public class DuraStoreStitchingRetrievalSource extends DuraStoreRetrievalSource 
     @Override
     protected Content doGetContent(ContentItem item, RetrievalListener listener) {
         log.debug("enter doGetContent: {}", item);
+
         if (null != item && chunkUtil.isChunk(item.getContentId())) {
             StringBuilder msg = new StringBuilder();
             msg.append("Unexpected content item: ");
@@ -117,6 +118,7 @@ public class DuraStoreStitchingRetrievalSource extends DuraStoreRetrievalSource 
                     }
                 }
             };
+
             return stitcher.getContentFromManifest(item.getSpaceId(),
                                                    item.getContentId(),
                                                    fileStitcherListener);

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreStitchingRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreStitchingRetrievalSource.java
@@ -131,8 +131,6 @@ public class DuraStoreStitchingRetrievalSource extends DuraStoreRetrievalSource 
                     msg.append(item);
                     msg.append(dse.getMessage());
 
-                    log.error(msg.toString());
-
                     throw new MissingContentException(msg.toString(), dse);
                 }
             } catch (ContentStoreException e) {

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreStitchingRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreStitchingRetrievalSource.java
@@ -7,7 +7,6 @@
  */
 package org.duracloud.retrieval.source;
 
-import java.text.MessageFormat;
 import java.util.List;
 
 import org.duracloud.chunk.manifest.ChunksManifest;

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreStitchingRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreStitchingRetrievalSource.java
@@ -7,6 +7,7 @@
  */
 package org.duracloud.retrieval.source;
 
+import java.text.MessageFormat;
 import java.util.List;
 
 import org.duracloud.chunk.manifest.ChunksManifest;
@@ -15,11 +16,14 @@ import org.duracloud.client.ContentStore;
 import org.duracloud.common.error.DuraCloudRuntimeException;
 import org.duracloud.common.model.ContentItem;
 import org.duracloud.domain.Content;
+import org.duracloud.error.ContentStoreException;
 import org.duracloud.retrieval.mgmt.RetrievalListener;
 import org.duracloud.stitch.FileStitcher;
 import org.duracloud.stitch.FileStitcherListener;
 import org.duracloud.stitch.datasource.impl.DuraStoreDataSource;
+import org.duracloud.stitch.error.DataSourceException;
 import org.duracloud.stitch.error.InvalidManifestException;
+import org.duracloud.stitch.error.MissingContentException;
 import org.duracloud.stitch.impl.FileStitcherImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +88,6 @@ public class DuraStoreStitchingRetrievalSource extends DuraStoreRetrievalSource 
     @Override
     protected Content doGetContent(ContentItem item, RetrievalListener listener) {
         log.debug("enter doGetContent: {}", item);
-
         if (null != item && chunkUtil.isChunk(item.getContentId())) {
             StringBuilder msg = new StringBuilder();
             msg.append("Unexpected content item: ");
@@ -114,10 +117,26 @@ public class DuraStoreStitchingRetrievalSource extends DuraStoreRetrievalSource 
                     }
                 }
             };
-
             return stitcher.getContentFromManifest(item.getSpaceId(),
                                                    item.getContentId(),
                                                    fileStitcherListener);
+        } catch (DataSourceException dse) {
+            try {
+                if (contentStore.contentExists(item.getSpaceId(), item.getContentId())) {
+                    throw dse;
+                } else {
+                    StringBuilder msg = new StringBuilder();
+                    msg.append("The item does not exist in the space: ");
+                    msg.append(item);
+                    msg.append(dse.getMessage());
+
+                    log.error(msg.toString());
+
+                    throw new MissingContentException(msg.toString(), dse);
+                }
+            } catch (ContentStoreException e) {
+                throw dse;
+            }
         } catch (InvalidManifestException e) {
             StringBuilder msg = new StringBuilder();
             msg.append("Unable to get content for ");

--- a/stitch/src/main/java/org/duracloud/stitch/error/MissingContentException.java
+++ b/stitch/src/main/java/org/duracloud/stitch/error/MissingContentException.java
@@ -1,0 +1,21 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.stitch.error;
+
+import org.duracloud.common.error.DuraCloudRuntimeException;
+
+/**
+ * @author Nicholas Woodward
+ * Date: 8/27/20
+ */
+public class MissingContentException extends DuraCloudRuntimeException {
+
+    public MissingContentException(String msg, Throwable throwable) {
+        super(msg, throwable);
+    }
+}

--- a/stitch/src/main/java/org/duracloud/stitch/impl/FileStitcherImpl.java
+++ b/stitch/src/main/java/org/duracloud/stitch/impl/FileStitcherImpl.java
@@ -27,6 +27,7 @@ import org.duracloud.domain.Content;
 import org.duracloud.stitch.FileStitcher;
 import org.duracloud.stitch.FileStitcherListener;
 import org.duracloud.stitch.datasource.DataSource;
+import org.duracloud.stitch.error.DataSourceException;
 import org.duracloud.stitch.error.InvalidManifestException;
 import org.duracloud.stitch.stream.MultiContentInputStream;
 import org.duracloud.stitch.stream.MultiContentInputStreamListener;
@@ -51,7 +52,7 @@ public class FileStitcherImpl implements FileStitcher {
 
     @Override
     public Content getContentFromManifest(String spaceId, String contentId, FileStitcherListener listener)
-        throws InvalidManifestException {
+        throws InvalidManifestException, DataSourceException {
         log.debug("getContentFromManifest({}, {})", spaceId, contentId);
 
         // verify contentId corresponds to the manifest naming convention.


### PR DESCRIPTION
**During the retrieval process, check for missing content and provide the user with an error message and a count of missing files at the end.**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/DURACLOUD-1267

# What does this Pull Request do?
Adds a check that the content IDs in a list-file actually exist in the space.

# How should this be tested?
1. Create a new space and upload a few files to it
2. Create a local text file with a list of the filenames
3. Add an additional filename that doesn't exist in the space to the list, e.g. foo.txt
4. Run a retrieval job on the command line with the local text file specified (-f)
5. Observe the retrieval logs for expected exception messages and note that the final output includes a missing files count

# Interested parties
@duracloud/committers
