### PR TITLE
DURACLOUD-1280: Add the SameSite attribute to CloudFront cookies

### DIFF
--- a/durastore/src/main/java/org/duracloud/durastore/rest/AuxRest.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/AuxRest.java
@@ -71,7 +71,7 @@ public class AuxRest extends BaseRest {
             for (String cookieKey : cookies.keySet()) {
                 responseCookies.add(new NewCookie(cookieKey,
                                                   cookies.get(cookieKey),
-                                                  "/",
+                                                  "/;SameSite=None",
                                                   streamingHost,
                                                   "Supports HLS",
                                                   -1,


### PR DESCRIPTION
**Adds SameSite attribute to CloudFront cookies**
* * *

**JIRA Ticket**: https://jira.lyrasis.org/browse/DURACLOUD-1280

# What does this Pull Request do?
This PR adds the "SameSite=None" setting to the 3 CloudFront cookies set as part of the flow for supporting secure HLS streaming. This setting is needed to allow pages with video players to make use of the cookies.

# How should this be tested?

* Build and deploy DuraStore with this change in place
* Turn on Secure HLS streaming for a space: https://wiki.lyrasis.org/display/DURACLOUDDOC/DuraCloud+REST+API#DuraCloudRESTAPI-HTTPLiveStreamingsupport
* Make a call to get the signed cookies url
```
POST http://localhost:8080/durastore/task/get-signed-cookies-url
{
  "spaceId" : "<space-with-secure-hls-streaming-enabled>",
  "redirectUrl" : "https://developer-tools.jwplayer.com/stream-tester"
}
```
* In the response to the POST above will be a "signedCookiesUrl" with a token value. Grab the token and make a call to get cookies:
```
GET http://localhost:8080/durastore/aux/cookies?token=<token-value-from-previous-call>
```
* Look in the headers of the response for "Set-Cookie" headers with value starting with "CloudFront" (there should be 3). Verify that in each there is the "SameSite=None;" setting

# Interested parties
@duracloud/committers
