### PR TITLE
DURACLOUD-1293: Updates /aux/cookies REST call to provide Access-Control-Allow-Origin header

### DIFF
--- a/common-rest/src/main/java/org/duracloud/common/rest/HttpHeaders.java
+++ b/common-rest/src/main/java/org/duracloud/common/rest/HttpHeaders.java
@@ -27,7 +27,7 @@ public interface HttpHeaders extends javax.ws.rs.core.HttpHeaders {
     public static final String UPGRADE = "Upgrade";
     public static final String WARNING = "Warning";
     public static final String X_FORWARDED_HOST = "X-FORWARDED-HOST";
-    public static final String X_FORWARDED_FOR = "X-FORWARDED-FOR";
     public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
+    public static final String ORIGIN = "Origin";
 
 }

--- a/common-rest/src/main/java/org/duracloud/common/rest/HttpHeaders.java
+++ b/common-rest/src/main/java/org/duracloud/common/rest/HttpHeaders.java
@@ -28,6 +28,7 @@ public interface HttpHeaders extends javax.ws.rs.core.HttpHeaders {
     public static final String WARNING = "Warning";
     public static final String X_FORWARDED_HOST = "X-FORWARDED-HOST";
     public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
+    public static final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";
     public static final String ORIGIN = "Origin";
 
 }

--- a/common-rest/src/main/java/org/duracloud/common/rest/HttpHeaders.java
+++ b/common-rest/src/main/java/org/duracloud/common/rest/HttpHeaders.java
@@ -27,5 +27,7 @@ public interface HttpHeaders extends javax.ws.rs.core.HttpHeaders {
     public static final String UPGRADE = "Upgrade";
     public static final String WARNING = "Warning";
     public static final String X_FORWARDED_HOST = "X-FORWARDED-HOST";
+    public static final String X_FORWARDED_FOR = "X-FORWARDED-FOR";
+    public static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
 
 }

--- a/durastore/src/main/java/org/duracloud/durastore/rest/AuxRest.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/AuxRest.java
@@ -18,7 +18,10 @@ import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.InetAddresses;
+import org.apache.commons.lang3.StringUtils;
 import org.duracloud.common.constant.Constants;
+import org.duracloud.common.rest.HttpHeaders;
 import org.duracloud.s3storage.StringDataStore;
 import org.duracloud.s3storage.StringDataStoreFactory;
 import org.duracloud.s3storageprovider.dto.SignedCookieData;
@@ -83,7 +86,20 @@ public class AuxRest extends BaseRest {
             String html = "<html><head><meta http-equiv='refresh' content='0;URL=\"" +
                           redirectUrl + "\"' /></head></html>";
 
+            // Capture the originating host from the request,
+            // pass it back in the CORS header in the response, defaults to "*"
+            String origin = "*";
+            String requestingHost = request.getHeader(HttpHeaders.X_FORWARDED_FOR);
+            if (StringUtils.isEmpty(requestingHost)) {
+                requestingHost = request.getRemoteHost();
+            }
+            if (!InetAddresses.isInetAddress(requestingHost) && // Use only hosts, not IPs
+                !StringUtils.isEmpty(requestingHost)) {
+                origin = "https://" + requestingHost;
+            }
+
             return Response.ok(html, MediaType.TEXT_HTML_TYPE)
+                           .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin)
                            .cookie(responseCookies.toArray(new NewCookie[responseCookies.size()])).build();
         } catch (Exception e) {
             return responseBad(e);

--- a/durastore/src/main/java/org/duracloud/durastore/rest/AuxRest.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/AuxRest.java
@@ -95,6 +95,7 @@ public class AuxRest extends BaseRest {
 
             return Response.ok(html, MediaType.TEXT_HTML_TYPE)
                            .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin)
+                           .header(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS, "true")
                            .header(HttpHeaders.VARY, HttpHeaders.ORIGIN)
                            .cookie(responseCookies.toArray(new NewCookie[responseCookies.size()])).build();
         } catch (Exception e) {

--- a/durastore/src/main/java/org/duracloud/durastore/rest/AuxRest.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/AuxRest.java
@@ -18,7 +18,6 @@ import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.net.InetAddresses;
 import org.apache.commons.lang3.StringUtils;
 import org.duracloud.common.constant.Constants;
 import org.duracloud.common.rest.HttpHeaders;
@@ -86,20 +85,17 @@ public class AuxRest extends BaseRest {
             String html = "<html><head><meta http-equiv='refresh' content='0;URL=\"" +
                           redirectUrl + "\"' /></head></html>";
 
-            // Capture the originating host from the request,
-            // pass it back in the CORS header in the response, defaults to "*"
+            // Capture the originating host from the request, pass it back in
+            // the CORS header in the response. Defaults to "*".
             String origin = "*";
-            String requestingHost = request.getHeader(HttpHeaders.X_FORWARDED_FOR);
-            if (StringUtils.isEmpty(requestingHost)) {
-                requestingHost = request.getRemoteHost();
-            }
-            if (!InetAddresses.isInetAddress(requestingHost) && // Use only hosts, not IPs
-                !StringUtils.isEmpty(requestingHost)) {
-                origin = "https://" + requestingHost;
+            String requestingOrigin = request.getHeader(HttpHeaders.ORIGIN);
+            if (!StringUtils.isEmpty(requestingOrigin)) {
+                origin = requestingOrigin;
             }
 
             return Response.ok(html, MediaType.TEXT_HTML_TYPE)
                            .header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin)
+                           .header(HttpHeaders.VARY, HttpHeaders.ORIGIN)
                            .cookie(responseCookies.toArray(new NewCookie[responseCookies.size()])).build();
         } catch (Exception e) {
             return responseBad(e);

--- a/durastore/src/main/java/org/duracloud/durastore/rest/TaskRest.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/TaskRest.java
@@ -138,7 +138,6 @@ public class TaskRest extends BaseRest {
 
     private Response responseOk(String msg, String text) {
         log.debug(msg);
-
         return Response.ok(text, TEXT_PLAIN).build();
     }
 

--- a/durastore/src/main/java/org/duracloud/durastore/rest/TaskRest.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/TaskRest.java
@@ -21,10 +21,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
-import com.google.common.net.InetAddresses;
-import org.apache.commons.lang3.StringUtils;
 import org.duracloud.StorageTaskConstants;
-import org.duracloud.common.rest.HttpHeaders;
 import org.duracloud.common.rest.RestUtil;
 import org.duracloud.common.util.IOUtil;
 import org.duracloud.common.util.SerializationUtil;
@@ -142,18 +139,7 @@ public class TaskRest extends BaseRest {
     private Response responseOk(String msg, String text) {
         log.debug(msg);
 
-        // Capture the host from the request to use with CORS header in response, defaults to "*"
-        String origin = "*";
-        String requestingHost = request.getHeader(HttpHeaders.X_FORWARDED_FOR);
-        if (StringUtils.isEmpty(requestingHost)) {
-            requestingHost = request.getRemoteHost();
-        }
-        if (!InetAddresses.isInetAddress(requestingHost) && // Don't use an IP
-            !StringUtils.isEmpty(requestingHost)) {
-            origin = "https://" + requestingHost;
-        }
-
-        return Response.ok(text, TEXT_PLAIN).header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin) .build();
+        return Response.ok(text, TEXT_PLAIN).build();
     }
 
     private Response responseOkXml(String msg, String text) {

--- a/durastore/src/main/java/org/duracloud/durastore/rest/TaskRest.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/TaskRest.java
@@ -21,7 +21,10 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
+import com.google.common.net.InetAddresses;
+import org.apache.commons.lang3.StringUtils;
 import org.duracloud.StorageTaskConstants;
+import org.duracloud.common.rest.HttpHeaders;
 import org.duracloud.common.rest.RestUtil;
 import org.duracloud.common.util.IOUtil;
 import org.duracloud.common.util.SerializationUtil;
@@ -138,7 +141,19 @@ public class TaskRest extends BaseRest {
 
     private Response responseOk(String msg, String text) {
         log.debug(msg);
-        return Response.ok(text, TEXT_PLAIN).build();
+
+        // Capture the host from the request to use with CORS header in response, defaults to "*"
+        String origin = "*";
+        String requestingHost = request.getHeader(HttpHeaders.X_FORWARDED_FOR);
+        if (StringUtils.isEmpty(requestingHost)) {
+            requestingHost = request.getRemoteHost();
+        }
+        if (!InetAddresses.isInetAddress(requestingHost) && // Don't use an IP
+            !StringUtils.isEmpty(requestingHost)) {
+            origin = "https://" + requestingHost;
+        }
+
+        return Response.ok(text, TEXT_PLAIN).header(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN, origin) .build();
     }
 
     private Response responseOkXml(String msg, String text) {

--- a/durastore/src/test/java/org/duracloud/durastore/rest/AuxRestTest.java
+++ b/durastore/src/test/java/org/duracloud/durastore/rest/AuxRestTest.java
@@ -85,8 +85,7 @@ public class AuxRestTest extends EasyMockSupport {
         String data = signedCookieData.serialize();
         expect(stringDataStore.retrieveData(token)).andReturn(data);
 
-        expect(request.getHeader(HttpHeaders.X_FORWARDED_FOR)).andReturn("");
-        expect(request.getRemoteHost()).andReturn("www.example.com");
+        expect(request.getHeader(HttpHeaders.ORIGIN)).andReturn("https://www.example.com");
 
         replayAll();
 

--- a/durastore/src/test/java/org/duracloud/durastore/rest/AuxRestTest.java
+++ b/durastore/src/test/java/org/duracloud/durastore/rest/AuxRestTest.java
@@ -14,9 +14,11 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 
+import org.duracloud.common.rest.HttpHeaders;
 import org.duracloud.s3storage.StringDataStore;
 import org.duracloud.s3storage.StringDataStoreFactory;
 import org.duracloud.s3storageprovider.dto.SignedCookieData;
@@ -45,6 +47,9 @@ public class AuxRestTest extends EasyMockSupport {
     private StringDataStoreFactory stringDataStoreFactory;
 
     @Mock
+    private HttpServletRequest request;
+
+    @Mock
     private StringDataStore stringDataStore;
 
     private String token = "token-uuid";
@@ -57,6 +62,7 @@ public class AuxRestTest extends EasyMockSupport {
             stringDataStore);
         this.auxRest = new AuxRest();
         this.auxRest.setStringDataStoreFactory(stringDataStoreFactory);
+        this.auxRest.request = request;
     }
 
     @After
@@ -78,7 +84,12 @@ public class AuxRestTest extends EasyMockSupport {
 
         String data = signedCookieData.serialize();
         expect(stringDataStore.retrieveData(token)).andReturn(data);
+
+        expect(request.getHeader(HttpHeaders.X_FORWARDED_FOR)).andReturn("");
+        expect(request.getRemoteHost()).andReturn("www.example.com");
+
         replayAll();
+
         Response response = this.auxRest.getCookies(token);
         assertEquals("200 response expected", 200, response.getStatus());
         assertEquals("2 cookies expected", 2, response.getCookies().size());
@@ -93,6 +104,8 @@ public class AuxRestTest extends EasyMockSupport {
         String html = response.getEntity().toString();
         assertTrue("response body must contain redirect url", html.contains("URL=\"" + myUrl + "\""));
         assertTrue("response must include refresh meta tag", html.contains("meta http-equiv='refresh'"));
+        assertEquals("https://www.example.com",
+                     response.getHeaders().get(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN).get(0));
     }
 
 }

--- a/durastore/src/test/java/org/duracloud/durastore/rest/AuxRestTest.java
+++ b/durastore/src/test/java/org/duracloud/durastore/rest/AuxRestTest.java
@@ -84,7 +84,6 @@ public class AuxRestTest extends EasyMockSupport {
 
         String data = signedCookieData.serialize();
         expect(stringDataStore.retrieveData(token)).andReturn(data);
-
         expect(request.getHeader(HttpHeaders.ORIGIN)).andReturn("https://www.example.com");
 
         replayAll();
@@ -103,6 +102,7 @@ public class AuxRestTest extends EasyMockSupport {
         String html = response.getEntity().toString();
         assertTrue("response body must contain redirect url", html.contains("URL=\"" + myUrl + "\""));
         assertTrue("response must include refresh meta tag", html.contains("meta http-equiv='refresh'"));
+        assertEquals(1, response.getHeaders().get(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN).size());
         assertEquals("https://www.example.com",
                      response.getHeaders().get(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN).get(0));
     }

--- a/durastore/src/test/java/org/duracloud/durastore/rest/AuxRestTest.java
+++ b/durastore/src/test/java/org/duracloud/durastore/rest/AuxRestTest.java
@@ -105,6 +105,8 @@ public class AuxRestTest extends EasyMockSupport {
         assertEquals(1, response.getHeaders().get(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN).size());
         assertEquals("https://www.example.com",
                      response.getHeaders().get(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN).get(0));
+        assertEquals("true",
+                     response.getHeaders().get(HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS).get(0));
     }
 
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/DURACLOUD-1293

# What does this Pull Request do?

On requests to the /aux/cookies REST endpoint (which are generally made through CloudFront), the new code looks for the Origin header and uses this to fill and return the Access-Control-Allow-Origin header in the response. This will allow XmlHttpRequest (AJAX) calls to interact with the Aux REST endpoint through Cloudfront as part of the secure HLS workflow.

The Access-Control-Allow-Credentials is also returned with value "true". As noted here: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#requests_with_credentials, the Access-Control-Allow-Credentials header is required (in combination with Access-Control-Allow-Origin) to allow XmlHttpRequest to work properly with "credentials" turned on, which is necessary if cookies are to be sent with the response.

# How should this be tested?

* Deploy updated DuraStore
* Enable secure HLS streaming
* Execute POST call to get the signed cookies url (i.e. POST to https://{host}/durastore/task/get-signed-cookies-url)
* The response will be a Cloudfront URL, as the value of "signedCookiesUrl" parameter in JSON. 
* Execute a GET call to the signedCookiesUrl with an Origin header
** Example: `curl -H "Origin: https://www.example.com" https://abcdefg.cloudfront.net/cookies?token=abcdefghijklmnopqrstuvwxyz -i`
* Verify that the result provides an Access-Control-Allow-Origin header with a value equal to the Origin value provided
* Verify that the result provides an Access-Control-Allow-Credentials header with value "true"

# Additional Notes:
Knowing whether this really accomplishes the necessary purpose will require making the call to the signedCookiesUrl via an XmlHttpRequest within an iframe, to see if the expected cloudfront cookies are set in the browser. I've coordinated with the user that indicated the issue in the first place and they have verified that this works when interacting with a dev DuraCloud instance with these changes applied.