### PR TITLE
DURACLOUD-1295: Updates the SyncTool installer to require Java 11

### DIFF
--- a/synctoolui/src/main/install/README
+++ b/synctoolui/src/main/install/README
@@ -3,11 +3,11 @@ ${project.name} v${project.version}.${buildNumber}
 Thank you for installing the DuraCloud Sync Tool.  To get going right away, simply launch the Sync Tool application and follow the instructions in the setup wizard.
 
 More information about the Sync Tool can be found here:
-https://wiki.duraspace.org/display/duraclouddoc/DuraCloud+Sync+Tool
+https://wiki.lyrasis.org/display/duraclouddoc/DuraCloud+Sync+Tool
 
 More information about DuraCloud can be found on the DuraCloud website:
 http://www.duracloud.org
 or the project wiki:
-https://wiki.duraspace.org/display/duracloud
+https://wiki.lyrasis.org/display/duracloud
 
 -The DuraCloud Development Team

--- a/synctoolui/src/main/install/installbuilder.xml
+++ b/synctoolui/src/main/install/installbuilder.xml
@@ -175,9 +175,7 @@
   <preInstallationActionList>
     <autodetectJava>
       <abortOnError>0</abortOnError>
-      <customErrorMessage>This program requires Java 1.7.0 or above. Click next and you will be taken to the java
-        downloads page.
-      </customErrorMessage>
+      <customErrorMessage>The DuraCloud SyncTool requires Java 11 or above. Click "OK" and you will be taken to the java downloads page.</customErrorMessage>
       <explanation>Checking for valid java version...</explanation>
       <promptUser>0</promptUser>
       <selectionOrder>newest</selectionOrder>
@@ -185,7 +183,7 @@
         <validVersion>
           <bitness></bitness>
           <maxVersion></maxVersion>
-          <minVersion>1.7.0</minVersion>
+          <minVersion>11.0.0</minVersion>
           <requireJDK>0</requireJDK>
           <vendor></vendor>
         </validVersion>
@@ -195,7 +193,7 @@
       </ruleList>
     </autodetectJava>
     <launchBrowser>
-      <url>http://java.com/en/download/index.jsp</url>
+      <url>https://www.oracle.com/java/technologies/javase-downloads.html</url>
       <ruleList>
         <ruleGroup ruleEvaluationLogic="and">
           <ruleList>
@@ -210,9 +208,7 @@
       </ruleList>
     </launchBrowser>
     <showInfo>
-      <text>Once you have finished downloading and installing java, click "OK" to continue with the Sync Tool
-        installation.
-      </text>
+      <text>Once you have finished downloading and installing java, click "OK" to continue with the Sync Tool installation.</text>
       <ruleList>
         <ruleGroup ruleEvaluationLogic="and">
           <ruleList>
@@ -232,7 +228,7 @@
         <validVersion>
           <bitness></bitness>
           <maxVersion></maxVersion>
-          <minVersion>1.7.0</minVersion>
+          <minVersion>11.0.0</minVersion>
           <requireJDK>0</requireJDK>
           <vendor></vendor>
         </validVersion>
@@ -268,7 +264,7 @@
             <validVersion>
               <bitness></bitness>
               <maxVersion></maxVersion>
-              <minVersion>1.7.0</minVersion>
+              <minVersion>11.0.0</minVersion>
               <requireJDK>0</requireJDK>
               <vendor></vendor>
             </validVersion>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/DURACLOUD-1295

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?

Requires Java 11 as part of the SyncTool installer. Also updates links in the SyncTool installer README

# How should this be tested?

* Attempt to install the SyncTool on a machine with either (1) no Java installed or (2) Java 8 installed
* Verify that the installer indicates that Java 11 is required and opens a download link
* Install Java (either 11 or 15) and retry the installer. This time it should continue with the installation.
