### PR TITLE
Updates SyncTool installer Java download link

### DIFF
--- a/synctoolui/src/main/install/installbuilder.xml
+++ b/synctoolui/src/main/install/installbuilder.xml
@@ -193,7 +193,7 @@
       </ruleList>
     </autodetectJava>
     <launchBrowser>
-      <url>https://www.oracle.com/java/technologies/javase-downloads.html</url>
+      <url>https://adoptopenjdk.net/</url>
       <ruleList>
         <ruleGroup ruleEvaluationLogic="and">
           <ruleList>


### PR DESCRIPTION
Changes the link set in DURACLOUD-1295 from oracle.com to adoptopenjdk.net

**JIRA Ticket**: An update to https://jira.lyrasis.org/browse/DURACLOUD-1295

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Replaces the Java download link presented to users when the SyncTool installer finds that Java 11 is not available on the local system.

# How should this be tested?
Build the SyncTool installer
Remove Java from your path
Run the SyncTool installer, verify that it provides the adoptopenjdk.net download link.
