### PR TITLE
Filter out extra Swift metadata

### DIFF
--- a/swiftstorageprovider/src/main/java/org/duracloud/swiftstorage/SwiftStorageProvider.java
+++ b/swiftstorageprovider/src/main/java/org/duracloud/swiftstorage/SwiftStorageProvider.java
@@ -60,6 +60,9 @@ public class SwiftStorageProvider extends S3StorageProvider {
         super(s3Client, accessKey, null);
     }
 
+    private static String[] SWIFT_METADATA_LIST =
+        {Headers.ETAG, Headers.CONTENT_LENGTH, Headers.DATE, Headers.LAST_MODIFIED, Headers.CONTENT_TYPE};
+
     /**
      * {@inheritDoc}
      */
@@ -264,8 +267,11 @@ public class SwiftStorageProvider extends S3StorageProvider {
             try {
                 if (!isSwiftMetadata(metaName)) {
                     Object metaValue = responseMeta.get(metaName);
-                    if (metaName.trim().equalsIgnoreCase(Headers.ETAG)) {
-                        metaName = Headers.ETAG;
+                    // Remove extra Swift metadata from user properties section
+                    for (String swiftMetaName : SWIFT_METADATA_LIST) {
+                        if (metaName.trim().equalsIgnoreCase(swiftMetaName)) {
+                            metaName = swiftMetaName;
+                        }
                     }
                     contentProperties.put(metaName, String.valueOf(metaValue));
                 }


### PR DESCRIPTION
**JIRA Ticket**: [DURACLOUD-1309](https://duracloud.atlassian.net/browse/DURACLOUD-1309)

# What does this Pull Request do?
Filter Content-Type, Content-Length, Last-Modified, and Date metadata out of the Properties section in the web UI.

# How should this be tested?
Swift's letter case of metadata tags does not match what DuraCloud expects and thus it shows up as user defined content properties.

Example in Response Headers:
[x-dura-meta-date|Mon, 07 Jun 2021 17:49:40 GMT]
[x-dura-meta-content-length|11666002]
[x-dura-meta-last-modified|Wed May 12 15:33:47 EDT 2021]
[x-dura-meta-content-type|application/pdf; charset=UTF-8]

To test, these extra metadata should not show up in the Properties section when accessing content stored in Swift storage provider.
