### PR TITLE
DURACLOUD-1310: use number in chunkId when index number is possibly missing in a chunk manifest

### DIFF
--- a/chunk/src/main/java/org/duracloud/chunk/manifest/ChunksManifest.java
+++ b/chunk/src/main/java/org/duracloud/chunk/manifest/ChunksManifest.java
@@ -72,7 +72,7 @@ public class ChunksManifest extends ChunksManifestBean {
                                            chunkSize));
     }
 
-    private int parseIndex(String chunkId) {
+    public int parseIndex(String chunkId) {
         String prefix = getHeader().getSourceContentId() + chunkSuffix;
         String num = chunkId.substring(prefix.length());
         try {

--- a/stitch/src/main/java/org/duracloud/stitch/impl/FileStitcherImpl.java
+++ b/stitch/src/main/java/org/duracloud/stitch/impl/FileStitcherImpl.java
@@ -120,18 +120,13 @@ public class FileStitcherImpl implements FileStitcher {
         // sort chunks by their index.
         Map<Integer, String> sortedChunkIds = new TreeMap<Integer, String>();
         for (ChunksManifestBean.ManifestEntry entry : manifest.getEntries()) {
-            log.info("The chunk manifest entry's chunkId is " + entry.getChunkId());
-            log.info("The chunk manifest entry's index is " + entry.getIndex());
-
             int parsedIndex = manifest.parseIndex(entry.getChunkId());
-            log.info("The chunk manifest entry's parsed index is " + parsedIndex);
 
             if (entry.getIndex() == parsedIndex) {
-                log.info("The chunk manifest entry's index and parsed index match.");
                 sortedChunkIds.put(entry.getIndex(), entry.getChunkId());
             } else {
-                log.info("The chunk manifest entry's index and parsed index do not match; using the latter as this" +
-                         " means the former is likely missing.");
+                log.info("The entry in the chunk manifest for chunk {} is missing an index field; using the index" +
+                         " from the filename instead.", entry.getChunkId());
                 sortedChunkIds.put(parsedIndex, entry.getChunkId());
             }
         }

--- a/stitch/src/main/java/org/duracloud/stitch/impl/FileStitcherImpl.java
+++ b/stitch/src/main/java/org/duracloud/stitch/impl/FileStitcherImpl.java
@@ -120,7 +120,20 @@ public class FileStitcherImpl implements FileStitcher {
         // sort chunks by their index.
         Map<Integer, String> sortedChunkIds = new TreeMap<Integer, String>();
         for (ChunksManifestBean.ManifestEntry entry : manifest.getEntries()) {
-            sortedChunkIds.put(entry.getIndex(), entry.getChunkId());
+            log.info("The chunk manifest entry's chunkId is " + entry.getChunkId());
+            log.info("The chunk manifest entry's index is " + entry.getIndex());
+
+            int parsedIndex = manifest.parseIndex(entry.getChunkId());
+            log.info("The chunk manifest entry's parsed index is " + parsedIndex);
+
+            if (entry.getIndex() == parsedIndex) {
+                log.info("The chunk manifest entry's index and parsed index match.");
+                sortedChunkIds.put(entry.getIndex(), entry.getChunkId());
+            } else {
+                log.info("The chunk manifest entry's index and parsed index do not match; using the latter as this" +
+                         " means the former is likely missing.");
+                sortedChunkIds.put(parsedIndex, entry.getChunkId());
+            }
         }
 
         // collect ordered sequence of chunk streams.


### PR DESCRIPTION
**This PR changes the file stitching process to handle cases where the index number is missing from entries in a chunk manifest.**
* * *

**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1310

# What does this Pull Request do?
Adds a comparison between the index number and the number at the end of each chunkId.

# How should this be tested?

1. Use the SyncTool to upload a large file that gets chunked to a DuraCloud space.
2. Modify only the dura-manifest file in the space by removing the `index=X` tag from each <chunk> tag.
3. Use the production version of the RetrievalTool to retrieve the file. It will fail with a checksum mismatch error.
4. Use this snapshot version of the RetrievalTool to retrieve the file.

# Interested parties
Tag @duracloud/committers
