### PR TITLE
DURACLOUD-1257: Allows audit config to complete init if RabbitMQ is not being used

### DIFF
--- a/durastore/src/main/java/org/duracloud/durastore/util/AuditConfigBuilder.java
+++ b/durastore/src/main/java/org/duracloud/durastore/util/AuditConfigBuilder.java
@@ -26,16 +26,19 @@ public class AuditConfigBuilder {
     public AuditConfig build() {
         AuditConfig config = new AuditConfig();
         DuracloudMill mill = millRepo.findAll().get(0);
-        RabbitmqConfig rmqConf = mill.getRabbitmqConfig();
         config.setAuditLogSpaceId(mill.getAuditLogSpaceId());
         config.setAuditQueueName(mill.getAuditQueue());
         config.setQueueType(QueueType.fromString(mill.getQueueType()));
-        config.setRabbitmqHost(rmqConf.getHost());
-        config.setRabbitmqPort(rmqConf.getPort());
-        config.setRabbitmqVhost(rmqConf.getVhost());
-        config.setRabbitmqExchange(mill.getRabbitmqExchange());
-        config.setRabbitmqUsername(rmqConf.getUsername());
-        config.setRabbitmqPassword(rmqConf.getPassword());
+
+        RabbitmqConfig rmqConf = mill.getRabbitmqConfig();
+        if (null != rmqConf) {
+            config.setRabbitmqHost(rmqConf.getHost());
+            config.setRabbitmqPort(rmqConf.getPort());
+            config.setRabbitmqVhost(rmqConf.getVhost());
+            config.setRabbitmqExchange(mill.getRabbitmqExchange());
+            config.setRabbitmqUsername(rmqConf.getUsername());
+            config.setRabbitmqPassword(rmqConf.getPassword());
+        }
         return config;
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1257

# What does this Pull Request do?

Allows DuraCloud to complete initialization when the audit queue is using SQS rather than RabbitMQ

# How should this be tested?

Use the Management Console to configure the use of SQS for the audit queue. Launch DuraCloud and ensure it comes up properly.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers

@fozboz 
