### PR TITLE
DURACLOUD-1268: refactor the RetrievalTool to create full list of contentIds, including chunked content, when a list-file is used

### DIFF
--- a/retrievaltool/pom.xml
+++ b/retrievaltool/pom.xml
@@ -41,6 +41,12 @@
 
     <dependency>
       <groupId>org.duracloud</groupId>
+      <artifactId>manifest</artifactId>
+      <version>7.1.0-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.duracloud</groupId>
       <artifactId>storeclient</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreRetrievalSource.java
@@ -53,7 +53,7 @@ public class DuraStoreRetrievalSource implements RetrievalSource {
     }
 
     protected Iterator<String> verifySpaceIds(List<String> spaces) throws RuntimeException {
-        Iterator<String> spaceIds = null;
+        Iterator<String> verifiedSpaceIds = null;
 
         if (spaces != null && spaces.size() > 0) {
             try {
@@ -71,7 +71,7 @@ public class DuraStoreRetrievalSource implements RetrievalSource {
                     throw new DuraCloudRuntimeException(error);
                 }
 
-                spaceIds = spaces.iterator();
+                verifiedSpaceIds = spaces.iterator();
             } catch (ContentStoreException cse) {
                 throw new DuraCloudRuntimeException("Error retrieving spaces list", cse);
             }
@@ -80,7 +80,7 @@ public class DuraStoreRetrievalSource implements RetrievalSource {
                                        "no content to retrieve");
         }
 
-        return spaceIds;
+        return verifiedSpaceIds;
     }
 
     @Override

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreRetrievalSource.java
@@ -49,19 +49,25 @@ public class DuraStoreRetrievalSource implements RetrievalSource {
             }
         }
 
+        this.spaceIds = verifySpaceIds(spaces);
+    }
+
+    protected Iterator<String> verifySpaceIds(List<String> spaces) throws RuntimeException {
+        Iterator<String> spaceIds = null;
+
         if (spaces != null && spaces.size() > 0) {
             try {
                 // check if provided spaces exist
-                List<String> spaceList = store.getSpaces();
-                List<String> nonExistantSpaces = new ArrayList<String>();
+                List<String> spaceList = this.contentStore.getSpaces();
+                List<String> nonExistentSpaces = new ArrayList<String>();
                 for (String space : spaces) {
                     if (!spaceList.contains(space)) {
-                        nonExistantSpaces.add(space);
+                        nonExistentSpaces.add(space);
                     }
                 }
-                if (!nonExistantSpaces.isEmpty()) {
+                if (!nonExistentSpaces.isEmpty()) {
                     String error = "The following provided spaces do not exist: " +
-                                   StringUtils.join(nonExistantSpaces, ", ");
+                                   StringUtils.join(nonExistentSpaces, ", ");
                     throw new DuraCloudRuntimeException(error);
                 }
 
@@ -73,6 +79,8 @@ public class DuraStoreRetrievalSource implements RetrievalSource {
             throw new RuntimeException("Spaces list is empty, there is " +
                                        "no content to retrieve");
         }
+
+        return spaceIds;
     }
 
     @Override

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreSpecifiedRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreSpecifiedRetrievalSource.java
@@ -13,26 +13,19 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.ParseException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
-import org.duracloud.chunk.manifest.ChunksManifest;
 import org.duracloud.chunk.util.ChunkUtil;
 import org.duracloud.client.ContentStore;
 import org.duracloud.common.constant.ManifestFormat;
 import org.duracloud.common.error.DuraCloudRuntimeException;
-import org.duracloud.common.model.ContentItem;
-import org.duracloud.domain.Content;
 import org.duracloud.error.ContentStoreException;
 import org.duracloud.manifest.ManifestFormatter;
 import org.duracloud.manifest.impl.ManifestFormatterFactory;
 import org.duracloud.mill.db.model.ManifestItem;
-import org.duracloud.retrieval.mgmt.RetrievalListener;
-import org.duracloud.stitch.error.MissingContentException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +71,7 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
 
     protected void reviewSpecifiedContentIdsForChunkedContent(List<String> singleSpaceList) {
         log.debug("enter reviewSpecifiedContentIdsForChunkedContent()");
+        System.out.println("Reviewing space manifest for content IDs in list-file.");
 
         List<String> retrievalContentIds = new ArrayList<String>();
         while (specifiedContentIds.hasNext()) {
@@ -122,7 +116,7 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
 
                         // check if spaceContentId is for chunk manifest
                         if (chunkUtil.isChunkManifest(spaceContentId)) {
-                            String rootContentId = StringUtils.removeEnd(spaceContentId, ChunksManifest.manifestSuffix);
+                            String rootContentId = chunkUtil.preChunkedContentId(spaceContentId);
                             log.debug("found chunk manifest for contentId from list-file: " + spaceContentId);
                             retrievalSpaceContentIds.put(rootContentId, spaceContentId);
                         } else {
@@ -151,7 +145,7 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
                               retrievalContentId, chunkManifestContentId);
                     retrievalContentIdsFinal.add(chunkManifestContentId);
                 } else {
-                    // silently add contentId since it matches
+                    // silently add contentId since it exists in space manifest
                     retrievalContentIdsFinal.add(retrievalContentId);
                 }
             } else {
@@ -160,6 +154,8 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
                 retrievalContentIdsFinal.add(retrievalContentId);
             }
         }
+
+        System.out.println("Finished reviewing space manifest for contentIDs in list-file.\n");
         this.specifiedContentIds = retrievalContentIdsFinal.iterator();
     }
 

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreSpecifiedRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreSpecifiedRetrievalSource.java
@@ -7,15 +7,27 @@
  */
 package org.duracloud.retrieval.source;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.lang.StringUtils;
 import org.duracloud.chunk.manifest.ChunksManifest;
 import org.duracloud.client.ContentStore;
+import org.duracloud.common.constant.ManifestFormat;
 import org.duracloud.common.error.DuraCloudRuntimeException;
 import org.duracloud.common.model.ContentItem;
 import org.duracloud.domain.Content;
 import org.duracloud.error.ContentStoreException;
+import org.duracloud.manifest.ManifestFormatter;
+import org.duracloud.manifest.impl.ManifestFormatterFactory;
+import org.duracloud.mill.db.model.ManifestItem;
 import org.duracloud.retrieval.mgmt.RetrievalListener;
 import org.duracloud.stitch.error.MissingContentException;
 import org.slf4j.Logger;
@@ -37,6 +49,7 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
     private final Logger log = LoggerFactory.getLogger(
         DuraStoreSpecifiedRetrievalSource.class);
 
+
     private Iterator<String> specifiedContentIds;
 
     public DuraStoreSpecifiedRetrievalSource(ContentStore store,
@@ -55,6 +68,81 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
         }
 
         this.specifiedContentIds = specifiedContentIds;
+        this.reviewSpecifiedContentIdsForChunkedContent(singleSpaceList);
+    }
+
+    protected void reviewSpecifiedContentIdsForChunkedContent(List<String> singleSpaceList) {
+        log.debug("enter remediateSpecifiedContentIds()");
+
+        List<String> retrievalContentIds = new ArrayList<String>();
+        while (specifiedContentIds.hasNext()) {
+            String temp = specifiedContentIds.next();
+            retrievalContentIds.add(temp);
+        }
+        log.debug("total contentIds in list-file: " + retrievalContentIds.size());
+
+        List<String> retrievalSpaceContentIds = new ArrayList<String>();
+
+        Iterator<String> retrievalSpaceIds = verifySpaceIds(singleSpaceList);
+        if (retrievalSpaceIds.hasNext()) {
+            String currentRetrievalSpaceId = retrievalSpaceIds.next();
+            log.debug("searching for contentIds in space: " + currentRetrievalSpaceId);
+            try {
+                InputStream manifest = contentStore.getManifest(currentRetrievalSpaceId, ManifestFormat.TSV);
+                ManifestFormatter formatter = new ManifestFormatterFactory().create(ManifestFormat.TSV);
+                String header = formatter.getHeader();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(manifest));
+                String line = null;
+                ManifestItem item = null;
+
+                try {
+                    while ((line = reader.readLine()) != null) {
+                        // ignore any whitespace
+                        if (line.trim().length() == 0) {
+                            continue;
+                        }
+
+                        // ignore header line
+                        if (line.equals(header)) {
+                            continue;
+                        }
+
+                        try {
+                            item = formatter.parseLine(line);
+                        } catch (ParseException e) {
+                            throw new IOException(e);
+                        }
+
+                        String contentId = item.getContentId();
+
+                        // search for chunks or chunk manifests for contentId
+                        String tempContentId = contentId;
+                        if (contentId.endsWith(ChunksManifest.manifestSuffix)) {
+                            tempContentId = StringUtils.removeEnd(contentId, ChunksManifest.manifestSuffix);
+                        } else if (contentId.contains(ChunksManifest.chunkSuffix)) {
+                            tempContentId = contentId.substring(0, contentId.indexOf(ChunksManifest.chunkSuffix));
+                        }
+
+                        if (retrievalContentIds.contains(tempContentId)) {
+                            log.debug("found chunked content for contentId in list-file: " + contentId);
+                            retrievalSpaceContentIds.add(contentId);
+                        }
+                    }
+                } catch (IOException ex) {
+                    log.error("Error reading space manifest.");
+                }
+            } catch (ContentStoreException cse) {
+                log.error("Unable to retrieve space manifest. If files-list.txt contains chunked files and the " +
+                          "retrieval fails the local content dir will need to be empty.");
+            }
+        }
+
+        if (!retrievalSpaceContentIds.isEmpty()) {
+            Collections.sort(retrievalSpaceContentIds);
+            log.debug("List of contentIds to retrieve has increased from " + retrievalContentIds.size() + " to " +
+                     retrievalSpaceContentIds.size() + " after chunked content is included.");
+            this.specifiedContentIds = retrievalSpaceContentIds.iterator();
+        }
     }
 
     @Override
@@ -62,27 +150,6 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
         if (spaceIds.hasNext()) {
             currentSpaceId = spaceIds.next();
             currentContentList = specifiedContentIds;
-        }
-    }
-
-    @Override
-    protected Content doGetContent(ContentItem item, RetrievalListener listener) {
-        try {
-            return contentStore.getContent(item.getSpaceId(),
-                                           item.getContentId());
-        } catch (ContentStoreException cse) {
-            log.info("Error retrieving content ID: " + item.getContentId() +
-                     ".  Trying to get this content again by checking for " +
-                     "a chunk manifest for this content ID.");
-            // Create a new ContentItem representing the manifest file content ID
-            // for the passed in ContentItem to this method.
-            ContentItem manifestItem = new ContentItem(item.getSpaceId(),
-                                                       item.getContentId() + ChunksManifest.manifestSuffix);
-            try {
-                return doGetContentFromManifest(manifestItem, listener);
-            } catch (MissingContentException mse) {
-                throw mse;
-            }
         }
     }
 }

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreSpecifiedRetrievalSource.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/source/DuraStoreSpecifiedRetrievalSource.java
@@ -69,7 +69,7 @@ public class DuraStoreSpecifiedRetrievalSource extends DuraStoreStitchingRetriev
         this.reviewSpecifiedContentIdsForChunkedContent(singleSpaceList);
     }
 
-    protected void reviewSpecifiedContentIdsForChunkedContent(List<String> singleSpaceList) {
+    private void reviewSpecifiedContentIdsForChunkedContent(List<String> singleSpaceList) {
         log.debug("enter reviewSpecifiedContentIdsForChunkedContent()");
         System.out.println("Reviewing space manifest for content IDs in list-file.");
 


### PR DESCRIPTION
**This PR changes the DuraStoreSpecifiedRetrievalSource class so that when a list-file is specified it creates a full list of contentIds to be retrieved, including any chunked content of files in the list-file.**
* * *

**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1268

# What does this Pull Request do?
This PR changes the class used by the RetrievalTool when a list-file is specified to work more like the default behavior when retrieving a space. As as result of this change, the two classes can now retrieve content with the same function. This PR resolves the case where the RetrievalTool with a list-file specified fails to transfer when restarting from partially chunked files.

# How should this be tested?

* Create a space in DuraCloud and use the SyncTool to add one or more large files that will be chunked
* Use the version 7.0 of the RetrievalTool with a file containing the contentIds in the space to start retrieving the space
* Hit Ctrl-C to stop the process. Restart the process and observe that it fails to retrieve the files
* Repeat the above process with the RetrievalTool built from this branch, and observe that the process finishes successfully

# Interested parties
@duracloud/committers
