### PR TITLE
DURACLOUD-1292: Updates dependency versions

### DIFF
--- a/chunk/src/main/java/org/duracloud/chunk/ChunkableContent.java
+++ b/chunk/src/main/java/org/duracloud/chunk/ChunkableContent.java
@@ -168,6 +168,10 @@ public class ChunkableContent implements Iterable<ChunkInputStream>, Iterator<Ch
             StringBuilder sb = new StringBuilder("Error: ");
             sb.append("Previous chunk not fully read: ");
             sb.append(currentChunk.getChunkId());
+            sb.append(" Chunk size: ");
+            sb.append(currentChunk.getChunkSize());
+            sb.append(", Bytes read: ");
+            sb.append(currentChunk.numBytesRead());
             log.error(sb.toString());
             throw new DuraCloudRuntimeException(sb.toString());
         }

--- a/chunk/src/main/java/org/duracloud/chunk/writer/FilesystemContentWriter.java
+++ b/chunk/src/main/java/org/duracloud/chunk/writer/FilesystemContentWriter.java
@@ -25,6 +25,7 @@ import org.duracloud.chunk.manifest.ChunksManifest;
 import org.duracloud.chunk.stream.ChunkInputStream;
 import org.duracloud.chunk.stream.KnownLengthInputStream;
 import org.duracloud.common.error.DuraCloudRuntimeException;
+import org.duracloud.common.util.IOUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -159,11 +160,7 @@ public class FilesystemContentWriter implements ContentWriter {
                                                        contentSize);
         result.setState(AddContentResult.State.SUCCESS);
         try {
-            if (contentSize > TWO_GB) {
-                copyLarge(inputStream, outStream);
-            } else {
-                copy(inputStream, outStream);
-            }
+            copy(inputStream, outStream);
         } catch (Exception e) {
             result.setState(AddContentResult.State.ERROR);
         }
@@ -174,20 +171,10 @@ public class FilesystemContentWriter implements ContentWriter {
         return result;
     }
 
-    private void copyLarge(InputStream chunk, OutputStream outStream) {
-        try {
-            IOUtils.copyLarge(chunk, outStream);
-        } catch (IOException e) {
-            String msg = "Error in copy: " + chunk.toString() + ": ";
-            log.error(msg, e);
-            throw new DuraCloudRuntimeException(msg + e.getMessage(), e);
-        }
-    }
-
     private void copy(InputStream chunk, OutputStream outStream) {
         try {
-            IOUtils.copy(chunk, outStream);
-        } catch (IOException e) {
+            IOUtil.copy(chunk, outStream);
+        } catch (DuraCloudRuntimeException e) {
             String msg = "Error in copy: " + chunk.toString() + ": ";
             log.error(msg, e);
             throw new DuraCloudRuntimeException(msg + e.getMessage(), e);

--- a/chunk/src/test/java/org/duracloud/chunk/ChunkableContentTest.java
+++ b/chunk/src/test/java/org/duracloud/chunk/ChunkableContentTest.java
@@ -27,6 +27,7 @@ import org.duracloud.chunk.stream.ChunkInputStream;
 import org.duracloud.chunk.stream.KnownLengthInputStream;
 import org.duracloud.common.error.DuraCloudRuntimeException;
 import org.duracloud.common.util.ChecksumUtil;
+import org.duracloud.common.util.IOUtil;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -90,7 +91,7 @@ public class ChunkableContentTest {
             chunkFiles.add(f);
 
             out = new FileOutputStream(f);
-            IOUtils.copy(chunk, out);
+            IOUtil.copy(chunk, out);
 
             IOUtils.closeQuietly(chunk);
             IOUtils.closeQuietly(out);

--- a/common/src/main/java/org/duracloud/common/util/IOUtil.java
+++ b/common/src/main/java/org/duracloud/common/util/IOUtil.java
@@ -31,6 +31,9 @@ import org.duracloud.common.error.DuraCloudRuntimeException;
  */
 public class IOUtil {
 
+    // Maintain default buffer size from commons-io prior to v2.7 (where it changed to 8192)
+    private static final int COPY_BUFFER_SIZE = 4096;
+
     private IOUtil() {
         // Ensures no instances are made of this class, as there are only static members.
     }
@@ -60,7 +63,7 @@ public class IOUtil {
 
     public static void copy(InputStream input, OutputStream output) {
         try {
-            IOUtils.copy(input, output);
+            IOUtils.copy(input, output, COPY_BUFFER_SIZE);
         } catch (IOException e) {
             throw new DuraCloudRuntimeException(e);
         }
@@ -95,7 +98,7 @@ public class IOUtil {
             if (gzip) {
                 outStream = new GZIPOutputStream(outStream);
             }
-            IOUtils.copy(inStream, outStream);
+            IOUtils.copy(inStream, outStream, COPY_BUFFER_SIZE);
         } catch (IOException e) {
             String err = "Error writing stream to file: " + e.getMessage();
 

--- a/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/AuditLogController.java
+++ b/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/AuditLogController.java
@@ -14,11 +14,11 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.duracloud.client.ContentStore;
 import org.duracloud.client.ContentStoreManager;
 import org.duracloud.common.util.DateUtil.DateFormat;
+import org.duracloud.common.util.IOUtil;
 import org.duracloud.error.ContentStoreException;
 import org.duracloud.error.NotFoundException;
 import org.slf4j.Logger;
@@ -66,7 +66,7 @@ public class AuditLogController {
                                       + ".tsv");
             contentDisposition.append("\"");
             response.setHeader("Content-Disposition", contentDisposition.toString());
-            IOUtils.copy(is, response.getOutputStream());
+            IOUtil.copy(is, response.getOutputStream());
         } catch (NotFoundException ex) {
             response.setStatus(HttpStatus.SC_NOT_FOUND);
 

--- a/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/ManifestController.java
+++ b/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/ManifestController.java
@@ -14,12 +14,12 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.duracloud.client.ContentStore;
 import org.duracloud.client.ContentStoreManager;
 import org.duracloud.common.constant.ManifestFormat;
 import org.duracloud.common.util.DateUtil.DateFormat;
+import org.duracloud.common.util.IOUtil;
 import org.duracloud.error.ContentStoreException;
 import org.duracloud.error.NotFoundException;
 import org.slf4j.Logger;
@@ -76,7 +76,7 @@ public class ManifestController {
                                       + extension);
             contentDisposition.append("\"");
             response.setHeader("Content-Disposition", contentDisposition.toString());
-            IOUtils.copy(is, response.getOutputStream());
+            IOUtil.copy(is, response.getOutputStream());
         } catch (NotFoundException ex) {
             response.setStatus(HttpStatus.SC_NOT_FOUND);
 

--- a/durastore/src/test/java/org/duracloud/durastore/util/ACLStorageProviderTest.java
+++ b/durastore/src/test/java/org/duracloud/durastore/util/ACLStorageProviderTest.java
@@ -283,7 +283,7 @@ public class ACLStorageProviderTest {
     @Test
     public void testClearCache() throws InterruptedException {
         String spaceId = "ACLStorageProvider-cache";
-        createMockStorageProvider(3);
+        createMockStorageProvider(2);
 
         expect(mockProvider.getSpaceACLs(spaceId))
             .andReturn(new HashMap<String, AclType>());

--- a/pom.xml
+++ b/pom.xml
@@ -238,11 +238,11 @@
     <org.springframework.security.version>4.0.4.RELEASE</org.springframework.security.version>
     <org.springframework.webflow.version>2.4.2.RELEASE</org.springframework.webflow.version>
     <hibernate.version>5.1.0.Final</hibernate.version>
-    <aws.sdk.version>1.11.155</aws.sdk.version>
+    <aws.sdk.version>1.12.24</aws.sdk.version>
     <jersey.version>2.5.1</jersey.version>
-    <jackson.version>2.7.4</jackson.version>
+    <jackson.version>2.12.3</jackson.version>
     <tiles.version>2.2.2</tiles.version>
-    <selenium.version>2.19.0</selenium.version>
+    <selenium.version>2.53.1</selenium.version>
     <slf4j.version>1.7.6</slf4j.version>
     <jetty.version>9.4.31.v20200723</jetty.version>
     <jaxb.api.version>2.3.1</jaxb.api.version>
@@ -634,7 +634,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.10</version>
+        <version>4.13.2</version>
         <exclusions>
           <exclusion>
             <groupId>log4j</groupId>
@@ -658,7 +658,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.1.2</version>
+        <version>1.2.0</version>
       </dependency>
 
       <dependency>
@@ -676,7 +676,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.7</version>
+        <version>1.4.17</version>
       </dependency>
 
       <dependency>
@@ -731,7 +731,7 @@
       <dependency>
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
-        <version>2.9.1</version>
+        <version>2.12.1</version>
       </dependency>
 
       <dependency>
@@ -773,13 +773,13 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.4</version>
+        <version>2.7</version>
       </dependency>
 
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.2</version>
+        <version>1.9.4</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -795,11 +795,15 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.2</version>
+        <version>4.5.13</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -807,13 +811,13 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpmime</artifactId>
-        <version>4.5.2</version>
+        <version>4.5.13</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>4.4.4</version>
+        <version>4.4.13</version>
       </dependency>
 
       <dependency>
@@ -943,7 +947,7 @@
       <dependency>
         <groupId>org.apache.xmlbeans</groupId>
         <artifactId>xmlbeans</artifactId>
-        <version>2.3.0</version>
+        <version>3.0.2</version>
       </dependency>
 
       <dependency>
@@ -1040,6 +1044,14 @@
           <exclusion>
             <groupId>cglib</groupId>
             <artifactId>cglib-nodep</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1297,7 +1309,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.9</version>
+        <version>1.15</version>
       </dependency>
 
       <dependency>
@@ -1382,6 +1394,12 @@
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-jaxb-annotations</artifactId>
         <version>${jackson.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -1464,7 +1482,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>17.0</version>
+        <version>30.1.1-jre</version>
       </dependency>
 
       <dependency>

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalWorker.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalWorker.java
@@ -21,13 +21,13 @@ import java.util.Date;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.duracloud.chunk.util.ChunkUtil;
 import org.duracloud.client.ContentStore;
 import org.duracloud.common.model.ContentItem;
 import org.duracloud.common.retry.Retrier;
 import org.duracloud.common.util.ChecksumUtil;
 import org.duracloud.common.util.DateUtil;
+import org.duracloud.common.util.IOUtil;
 import org.duracloud.retrieval.source.ContentStream;
 import org.duracloud.retrieval.source.RetrievalSource;
 import org.duracloud.stitch.error.MissingContentException;
@@ -249,7 +249,7 @@ public class RetrievalWorker implements Runnable {
             InputStream inStream = contentStream.getStream();
             OutputStream outStream = new FileOutputStream(localFile);
         ) {
-            IOUtils.copyLarge(inStream, outStream);
+            IOUtil.copy(inStream, outStream);
         } catch (IOException e) {
             try {
                 deleteFile(localFile);

--- a/retrievaltool/src/test/java/org/duracloud/retrieval/source/DuraStoreRetrievalSourceTest.java
+++ b/retrievaltool/src/test/java/org/duracloud/retrieval/source/DuraStoreRetrievalSourceTest.java
@@ -20,9 +20,9 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.IOUtils;
 import org.duracloud.client.ContentStore;
 import org.duracloud.common.model.ContentItem;
+import org.duracloud.common.util.IOUtil;
 import org.duracloud.domain.Content;
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
@@ -127,7 +127,7 @@ public class DuraStoreRetrievalSourceTest {
         assertEquals(checksum, contentStream.getChecksum());
 
         ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-        IOUtils.copy(contentStream.getStream(), outStream);
+        IOUtil.copy(contentStream.getStream(), outStream);
         assertEquals(value, outStream.toString("UTF-8"));
     }
 

--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3ProviderUtil.java
@@ -103,13 +103,23 @@ public class S3ProviderUtil {
                 } else {
                     awsRegion = System.getProperty(OPTS.AWS_REGION.name());
                 }
-                // Construct a normal client that connects to AWS.
-                log.debug("Creating AWS S3 Client.");
-                s3Client = AmazonS3ClientBuilder
-                    .standard()
-                    .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
-                    .withRegion(awsRegion)
-                    .build();
+
+                if (null == awsRegion) {
+                    // Construct an AWS client with no region set (the provider chain will be consulted)
+                    log.debug("Creating AWS S3 Client with no explicit region.");
+                    s3Client = AmazonS3ClientBuilder
+                        .standard()
+                        .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                        .build();
+                } else {
+                    // Construct an AWS client with a specified region
+                    log.debug("Creating AWS S3 Client with region: " + awsRegion);
+                    s3Client = AmazonS3ClientBuilder
+                        .standard()
+                        .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                        .withRegion(awsRegion)
+                        .build();
+                }
             } else {
                 // Construct a client that will work with S3+Swift
                 log.debug("Creating Swift S3 client.");

--- a/stitch/src/main/java/org/duracloud/stitch/FileStitcherDriver.java
+++ b/stitch/src/main/java/org/duracloud/stitch/FileStitcherDriver.java
@@ -27,6 +27,7 @@ import org.duracloud.client.ContentStoreManager;
 import org.duracloud.client.ContentStoreManagerImpl;
 import org.duracloud.common.error.DuraCloudRuntimeException;
 import org.duracloud.common.model.Credential;
+import org.duracloud.common.util.IOUtil;
 import org.duracloud.domain.Content;
 import org.duracloud.error.ContentStoreException;
 import org.duracloud.stitch.datasource.DataSource;
@@ -105,7 +106,7 @@ public class FileStitcherDriver {
 
             // Write content
             outputStream = new FileOutputStream(outFile);
-            IOUtils.copyLarge(content.getStream(), outputStream);
+            IOUtil.copy(content.getStream(), outputStream);
 
         } catch (IOException e) {
             StringBuilder msg = new StringBuilder();

--- a/stitch/src/test/java/org/duracloud/stitch/impl/FileStitcherImplTest.java
+++ b/stitch/src/test/java/org/duracloud/stitch/impl/FileStitcherImplTest.java
@@ -25,9 +25,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.io.IOUtils;
 import org.duracloud.chunk.manifest.ChunksManifest;
 import org.duracloud.chunk.manifest.xml.ManifestDocumentBinding;
+import org.duracloud.common.util.IOUtil;
 import org.duracloud.domain.Content;
 import org.duracloud.stitch.FileStitcher;
 import org.duracloud.stitch.FileStitcherListener;
@@ -171,7 +171,7 @@ public class FileStitcherImplTest {
         Assert.assertNotNull(contentStream);
 
         OutputStream outputStream = new ByteArrayOutputStream();
-        IOUtils.copy(contentStream, outputStream);
+        IOUtil.copy(contentStream, outputStream);
 
         String fullContent = outputStream.toString();
         contentStream.close();

--- a/stitch/src/test/java/org/duracloud/stitch/stream/MultiContentInputStreamTest.java
+++ b/stitch/src/test/java/org/duracloud/stitch/stream/MultiContentInputStreamTest.java
@@ -14,8 +14,8 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.IOUtils;
 import org.duracloud.common.model.ContentItem;
+import org.duracloud.common.util.IOUtil;
 import org.duracloud.domain.Content;
 import org.duracloud.stitch.datasource.DataSource;
 import org.easymock.EasyMock;
@@ -69,7 +69,7 @@ public class MultiContentInputStreamTest {
         OutputStream out = new ByteArrayOutputStream();
 
         multiStream = new MultiContentInputStream(dataSource, contentItems);
-        IOUtils.copy(multiStream, out);
+        IOUtil.copy(multiStream, out);
         Assert.assertEquals(text, out.toString());
         out.close();
     }
@@ -85,7 +85,7 @@ public class MultiContentInputStreamTest {
 
         OutputStream out = new ByteArrayOutputStream();
         multiStream = new MultiContentInputStream(dataSource, contentItems, listener);
-        IOUtils.copy(multiStream, out);
+        IOUtil.copy(multiStream, out);
         Assert.assertEquals(text, out.toString());
         out.close();
     }

--- a/synctool/src/main/java/org/duracloud/sync/config/SyncToolConfigParser.java
+++ b/synctool/src/main/java/org/duracloud/sync/config/SyncToolConfigParser.java
@@ -518,9 +518,8 @@ public class SyncToolConfigParser {
         String[] config = null;
         if (configBackupFile.exists()) {
             ArrayList<String> args = new ArrayList<String>();
-            try {
-                BufferedReader backupReader =
-                    new BufferedReader(new FileReader(configBackupFile));
+            try (BufferedReader backupReader =
+                     new BufferedReader(new FileReader(configBackupFile))) {
                 String line = backupReader.readLine();
                 while (line != null) {
                     args.add(line);

--- a/synctool/src/main/java/org/duracloud/sync/endpoint/FileSystemSyncEndpoint.java
+++ b/synctool/src/main/java/org/duracloud/sync/endpoint/FileSystemSyncEndpoint.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
+import org.duracloud.common.util.IOUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +71,7 @@ public class FileSystemSyncEndpoint implements SyncEndpoint {
                 }
                 inStream = syncFile.getStream();
                 outStream = new FileOutputStream(syncToFile);
-                IOUtils.copy(inStream, outStream);
+                IOUtil.copy(inStream, outStream);
                 success = true;
             } catch (IOException e) {
                 logger.error("Unable to sync updated file " +


### PR DESCRIPTION
**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1292

# What does this Pull Request do?

Updates dependencies used by DuraCloud as well as the Management Console, Mill, and Snapshot projects.

# How should this be tested?

There should be no functional changes. If the applications build, deploy, pass tests, and work as normal, then these changes were successful.

# Additional Notes:

A change to the default stream copy buffer in commons-io caused the chunking process to fail. To resolve this I set the buffer explicitly to the old value (4096) in the IOUtil utility class and updated code that had been using the commons-io class directly to use IOUtil instead.

# Interested parties
@duracloud/committers
