### PR TITLE
DURACLOUD-1319: Resolves app launch failure due to notification queue recreation

### DIFF
--- a/common-changenotifier/src/main/java/org/duracloud/common/changenotifier/SnsSubscriptionManager.java
+++ b/common-changenotifier/src/main/java/org/duracloud/common/changenotifier/SnsSubscriptionManager.java
@@ -71,7 +71,7 @@ public class SnsSubscriptionManager implements SubscriptionManager {
             //create sqs queue
             try {
                 final var queueName = this.queueName;
-                this.queueUrl = new Retrier(3, 20, 2).execute(() -> {
+                this.queueUrl = new Retrier(7, 2000, 2).execute(() -> {
                     log.info("creating sqs queue");
                     CreateQueueRequest request = new CreateQueueRequest(queueName);
                     Map<String, String> attributes = new HashMap<String, String>();


### PR DESCRIPTION
**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1319

# What does this Pull Request do?

Extends the retry timeline for creating the notification queue to accommodate the AWS requirement that queues of the same name that are deleted and recreated must have a 60 second window between these actions.

# How should this be tested?

Have the DuraCloud apps running locally. Run a build and allow them to be redeployed. Verify that the apps launch properly after the rebuild (without needing a container restart).
