### PR TITLE
DURACLOUD-1150: Add REST API endpoints for total size and files in snapshots

### DIFF
--- a/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotCountBridgeResult.java
+++ b/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotCountBridgeResult.java
@@ -1,0 +1,75 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.snapshot.dto.bridge;
+
+import java.io.IOException;
+import javax.xml.bind.annotation.XmlValue;
+
+import org.duracloud.common.json.JaxbJsonSerializer;
+import org.duracloud.snapshot.dto.BaseDTO;
+import org.duracloud.snapshot.error.SnapshotDataException;
+
+/**
+ * @author Nicholas Woodward
+ * Date: 7/15/21
+ */
+public class GetSnapshotCountBridgeResult extends BaseDTO {
+
+    /**
+     * The details of the current status
+     */
+    @XmlValue
+    private Long count;
+
+    public GetSnapshotCountBridgeResult() {
+    }
+
+    public GetSnapshotCountBridgeResult(Long count) {
+        this.count = count;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(Long count) {
+        this.count = count;
+    }
+
+    /**
+     * Creates a serialized version of bridge result
+     *
+     * @return JSON formatted bridge info
+     */
+    public String serialize() {
+        JaxbJsonSerializer<GetSnapshotCountBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotCountBridgeResult.class);
+        try {
+            return serializer.serialize(this);
+        } catch (IOException e) {
+            throw new SnapshotDataException("Unable to create task result due to: " +
+                                            e.getMessage());
+        }
+    }
+
+    /**
+     * Parses properties from bridge result string
+     *
+     * @param bridgeResult - JSON formatted set of properties
+     */
+    public static GetSnapshotCountBridgeResult deserialize(String bridgeResult) {
+        JaxbJsonSerializer<GetSnapshotCountBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotCountBridgeResult.class);
+        try {
+            return serializer.deserialize(bridgeResult);
+        } catch (IOException e) {
+            throw new SnapshotDataException(
+                "Unable to deserialize result due to: " + e.getMessage());
+        }
+    }
+}

--- a/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotTotalCountBridgeResult.java
+++ b/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotTotalCountBridgeResult.java
@@ -18,27 +18,27 @@ import org.duracloud.snapshot.error.SnapshotDataException;
  * @author Nicholas Woodward
  * Date: 7/15/21
  */
-public class GetSnapshotCountBridgeResult extends BaseDTO {
+public class GetSnapshotTotalCountBridgeResult extends BaseDTO {
 
     /**
      * The details of the current status
      */
     @XmlValue
-    private Long count;
+    private Long totalCount;
 
-    public GetSnapshotCountBridgeResult() {
+    public GetSnapshotTotalCountBridgeResult() {
     }
 
-    public GetSnapshotCountBridgeResult(Long count) {
-        this.count = count;
+    public GetSnapshotTotalCountBridgeResult(Long totalCount) {
+        this.totalCount = totalCount;
     }
 
-    public long getCount() {
-        return count;
+    public long getTotalCount() {
+        return totalCount;
     }
 
-    public void setCount(Long count) {
-        this.count = count;
+    public void setTotalCount(Long totalCount) {
+        this.totalCount = totalCount;
     }
 
     /**
@@ -47,8 +47,8 @@ public class GetSnapshotCountBridgeResult extends BaseDTO {
      * @return JSON formatted bridge info
      */
     public String serialize() {
-        JaxbJsonSerializer<GetSnapshotCountBridgeResult> serializer =
-            new JaxbJsonSerializer<>(GetSnapshotCountBridgeResult.class);
+        JaxbJsonSerializer<GetSnapshotTotalCountBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotTotalCountBridgeResult.class);
         try {
             return serializer.serialize(this);
         } catch (IOException e) {
@@ -62,9 +62,9 @@ public class GetSnapshotCountBridgeResult extends BaseDTO {
      *
      * @param bridgeResult - JSON formatted set of properties
      */
-    public static GetSnapshotCountBridgeResult deserialize(String bridgeResult) {
-        JaxbJsonSerializer<GetSnapshotCountBridgeResult> serializer =
-            new JaxbJsonSerializer<>(GetSnapshotCountBridgeResult.class);
+    public static GetSnapshotTotalCountBridgeResult deserialize(String bridgeResult) {
+        JaxbJsonSerializer<GetSnapshotTotalCountBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotTotalCountBridgeResult.class);
         try {
             return serializer.deserialize(bridgeResult);
         } catch (IOException e) {

--- a/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotTotalFilesBridgeResult.java
+++ b/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotTotalFilesBridgeResult.java
@@ -1,0 +1,75 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.snapshot.dto.bridge;
+
+import java.io.IOException;
+import javax.xml.bind.annotation.XmlValue;
+
+import org.duracloud.common.json.JaxbJsonSerializer;
+import org.duracloud.snapshot.dto.BaseDTO;
+import org.duracloud.snapshot.error.SnapshotDataException;
+
+/**
+ * @author Nicholas Woodward
+ * Date: 7/15/21
+ */
+public class GetSnapshotTotalFilesBridgeResult extends BaseDTO {
+
+    /**
+     * The details of the current status
+     */
+    @XmlValue
+    private Long totalFiles;
+
+    public GetSnapshotTotalFilesBridgeResult() {
+    }
+
+    public GetSnapshotTotalFilesBridgeResult(Long totalFiles) {
+        this.totalFiles = totalFiles;
+    }
+
+    public long getTotalFiles() {
+        return totalFiles;
+    }
+
+    public void setTotalFiles(Long totalFiles) {
+        this.totalFiles = totalFiles;
+    }
+
+    /**
+     * Creates a serialized version of bridge result
+     *
+     * @return JSON formatted bridge info
+     */
+    public String serialize() {
+        JaxbJsonSerializer<GetSnapshotTotalFilesBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotTotalFilesBridgeResult.class);
+        try {
+            return serializer.serialize(this);
+        } catch (IOException e) {
+            throw new SnapshotDataException("Unable to create task result due to: " +
+                                            e.getMessage());
+        }
+    }
+
+    /**
+     * Parses properties from bridge result string
+     *
+     * @param bridgeResult - JSON formatted set of properties
+     */
+    public static GetSnapshotTotalFilesBridgeResult deserialize(String bridgeResult) {
+        JaxbJsonSerializer<GetSnapshotTotalFilesBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotTotalFilesBridgeResult.class);
+        try {
+            return serializer.deserialize(bridgeResult);
+        } catch (IOException e) {
+            throw new SnapshotDataException(
+                "Unable to deserialize result due to: " + e.getMessage());
+        }
+    }
+}

--- a/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotTotalSizeBridgeResult.java
+++ b/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotTotalSizeBridgeResult.java
@@ -1,0 +1,75 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.snapshot.dto.bridge;
+
+import java.io.IOException;
+import javax.xml.bind.annotation.XmlValue;
+
+import org.duracloud.common.json.JaxbJsonSerializer;
+import org.duracloud.snapshot.dto.BaseDTO;
+import org.duracloud.snapshot.error.SnapshotDataException;
+
+/**
+ * @author Nicholas Woodward
+ * Date: 7/15/21
+ */
+public class GetSnapshotTotalSizeBridgeResult extends BaseDTO {
+
+    /**
+     * The details of the current status
+     */
+    @XmlValue
+    private Long totalSize;
+
+    public GetSnapshotTotalSizeBridgeResult() {
+    }
+
+    public GetSnapshotTotalSizeBridgeResult(Long totalSize) {
+        this.totalSize = totalSize;
+    }
+
+    public long getTotalSize() {
+        return totalSize;
+    }
+
+    public void setTotalSize(Long totalSize) {
+        this.totalSize = totalSize;
+    }
+
+    /**
+     * Creates a serialized version of bridge result
+     *
+     * @return JSON formatted bridge info
+     */
+    public String serialize() {
+        JaxbJsonSerializer<GetSnapshotTotalSizeBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotTotalSizeBridgeResult.class);
+        try {
+            return serializer.serialize(this);
+        } catch (IOException e) {
+            throw new SnapshotDataException("Unable to create task result due to: " +
+                                            e.getMessage());
+        }
+    }
+
+    /**
+     * Parses properties from bridge result string
+     *
+     * @param bridgeResult - JSON formatted set of properties
+     */
+    public static GetSnapshotTotalSizeBridgeResult deserialize(String bridgeResult) {
+        JaxbJsonSerializer<GetSnapshotTotalSizeBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotTotalSizeBridgeResult.class);
+        try {
+            return serializer.deserialize(bridgeResult);
+        } catch (IOException e) {
+            throw new SnapshotDataException(
+                "Unable to deserialize result due to: " + e.getMessage());
+        }
+    }
+}

--- a/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotTotalsBridgeResult.java
+++ b/snapshotdata/src/main/java/org/duracloud/snapshot/dto/bridge/GetSnapshotTotalsBridgeResult.java
@@ -1,0 +1,99 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.snapshot.dto.bridge;
+
+import java.io.IOException;
+import javax.xml.bind.annotation.XmlValue;
+
+import org.duracloud.common.json.JaxbJsonSerializer;
+import org.duracloud.snapshot.dto.BaseDTO;
+import org.duracloud.snapshot.error.SnapshotDataException;
+
+/**
+ * @author Nicholas Woodward
+ * Date: 7/15/21
+ */
+public class GetSnapshotTotalsBridgeResult extends BaseDTO {
+
+    /**
+     * The details of the current status
+     */
+    @XmlValue
+    private Long totalCount;
+
+    @XmlValue
+    private Long totalSize;
+
+    @XmlValue
+    private Long totalFiles;
+
+    public GetSnapshotTotalsBridgeResult() {
+    }
+
+    public GetSnapshotTotalsBridgeResult(Long totalCount, Long totalSize, Long totalFiles) {
+        this.totalCount = totalCount;
+        this.totalSize = totalSize;
+        this.totalFiles = totalFiles;
+    }
+
+    public long getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(Long totalCount) {
+        this.totalCount = totalCount;
+    }
+
+    public long getTotalSize() {
+        return totalSize;
+    }
+
+    public void setTotalSize(Long totalSize) {
+        this.totalSize = totalSize;
+    }
+
+    public long getTotalFiles() {
+        return totalFiles;
+    }
+
+    public void setTotalFiles(Long totalFiles) {
+        this.totalFiles = totalFiles;
+    }
+
+    /**
+     * Creates a serialized version of bridge result
+     *
+     * @return JSON formatted bridge info
+     */
+    public String serialize() {
+        JaxbJsonSerializer<GetSnapshotTotalsBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotTotalsBridgeResult.class);
+        try {
+            return serializer.serialize(this);
+        } catch (IOException e) {
+            throw new SnapshotDataException("Unable to create task result due to: " +
+                                            e.getMessage());
+        }
+    }
+
+    /**
+     * Parses properties from bridge result string
+     *
+     * @param bridgeResult - JSON formatted set of properties
+     */
+    public static GetSnapshotTotalsBridgeResult deserialize(String bridgeResult) {
+        JaxbJsonSerializer<GetSnapshotTotalsBridgeResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotTotalsBridgeResult.class);
+        try {
+            return serializer.deserialize(bridgeResult);
+        } catch (IOException e) {
+            throw new SnapshotDataException(
+                "Unable to deserialize result due to: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
**This PR works in tandem with the snapshot repository PR for new endpoints – https://github.com/duracloud/snapshot/pull/30. It adds three Bridge result classes for the new REST API endpoints that provide total snapshot count, snapshot size and snapshot files.**
* * *

**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1150

# How should this be tested?

* Build and install (push to local maven repository) this PR
* Build and deploy the Bridge from https://github.com/duracloud/snapshot/pull/30

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
