### PR TITLE
Addresses incompatibilities with mysql 8.x

### DIFF
--- a/durastore/src/main/java/org/duracloud/durastore/rest/StorageStatsResource.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/StorageStatsResource.java
@@ -8,7 +8,6 @@
 package org.duracloud.durastore.rest;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -57,7 +56,7 @@ public class StorageStatsResource {
             this.spaceStatsRepo.getByAccountIdAndStoreIdAndSpaceId(accountId, storeId, spaceId, start, end, interval);
         List<SpaceStatsDTO> dtos = new ArrayList<>(list.size());
         for (Object[] s : list) {
-            dtos.add(new SpaceStatsDTO(new Date(((BigInteger) s[0]).longValue() * 1000),
+            dtos.add(new SpaceStatsDTO(new Date(((Number) s[0]).longValue() * 1000),
                                        s[1].toString(),
                                        s[2].toString(),
                                        s[3].toString(),
@@ -93,7 +92,7 @@ public class StorageStatsResource {
         List<Object[]> list = this.spaceStatsRepo.getByAccountIdAndStoreId(account, storeId, start, end, interval);
         List<StoreStatsDTO> dtos = new ArrayList<>(list.size());
         for (Object[] s : list) {
-            dtos.add(new StoreStatsDTO(new Date(((BigInteger) s[0]).longValue() * 1000),
+            dtos.add(new StoreStatsDTO(new Date(((Number) s[0]).longValue() * 1000),
                                        s[1].toString(),
                                        s[2].toString(),
                                        ((BigDecimal) s[3]).longValue(),


### PR DESCRIPTION
**Addresses incompatibilities with mysql 8.x**
* * *

**JIRA Ticket**:https://duracloud.atlassian.net/browse/DURACLOUD-1298

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
Makes the storage report API compatible with mysql 8.  This change should be backwards compatible.
# How should this be tested?
Deploy against mysql 8.x
Navigate to a space in duradmin.
Verify that the storage reports are visible and no errors are displayed.

A description of what steps someone could take to:
To reproduce the error, run without this change against mysql 8 - the duradmin UI will report a failure to display the time series.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
