### PR TITLE
DURACLOUD-1279: Adds snapshot totals information to the UI, companion PR to DURACLOUD-1150

### DIFF
--- a/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/SnapshotController.java
+++ b/duradmin/src/main/java/org/duracloud/duradmin/spaces/controller/SnapshotController.java
@@ -149,6 +149,18 @@ public class SnapshotController {
         }
     }
 
+    @RequestMapping(value = "/spaces/snapshots/totals/{storeId}", method = RequestMethod.GET)
+    @ResponseBody
+    public String getSnapshotTotals(@PathVariable("storeId") String storeId,
+                                    @RequestParam(value = "status", required = false) String status) {
+        try {
+            return getTaskClient(storeId).getSnapshotsTotals(status).serialize();
+        } catch (ContentStoreException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
     @RequestMapping(value = "/spaces/snapshots/{storeId}/{snapshotId:.+}", method = RequestMethod.GET)
     @ResponseBody
     public String getSnapshot(@PathVariable("storeId") String storeId,

--- a/duradmin/src/main/webapp/jquery/dc/api/durastore-api.js
+++ b/duradmin/src/main/webapp/jquery/dc/api/durastore-api.js
@@ -495,7 +495,16 @@ var dc;
             type: "get",
         });
     };
-    
+
+    dc.store.GetSnapshotTotals = function(storeId, status) {
+        return dc.ajax2({
+            url: "/duradmin/spaces/snapshots/totals/" + storeId + "?status=" + status,
+            async: true,
+            dataType: 'json',
+            type: "get",
+        });
+    };
+
     dc.store.GetSnapshot = function(params){
         
         return dc.ajax2({

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -2978,11 +2978,12 @@ $(function() {
     load : function(storeId) {
       this._storeId = storeId;
 
-      if (this._isAdmin() && this._isSnapshot(storeId))  {
-        var totalsDiv = $.fn.create("div").addClass("totals-table");
-        this._appendToCenter(totalsDiv);
-
-        this._loadSnapshotsTotals(totalsDiv);
+      if (this._isAdmin())  {
+        if (this._isSnapshot(storeId)) {
+            var totalsDiv = $.fn.create("div").addClass("totals-table");
+            this._appendToCenter(totalsDiv);
+            this._loadSnapshotsTotals(totalsDiv);
+        }
 
         var history = $.fn.create("div");
         this._appendToCenter(history);

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -2978,7 +2978,12 @@ $(function() {
     load : function(storeId) {
       this._storeId = storeId;
 
-      if (this._isAdmin()) {
+      if (this._isAdmin() && this._isSnapshot(storeId))  {
+        var totalsDiv = $.fn.create("div").addClass("totals-table");
+        this._appendToCenter(totalsDiv);
+
+        this._loadSnapshotsTotals(totalsDiv);
+
         var history = $.fn.create("div");
         this._appendToCenter(history);
         history.historypanel({
@@ -2986,6 +2991,34 @@ $(function() {
         });
       }
 
+    },
+
+    _loadSnapshotsTotals : function(totalsDiv) {
+      $.when(this._getTotals()).done(function(result) {
+        var totals = result;
+
+        var props = [];
+
+        props.push([ 'Snapshots', totals.totalCount ]);
+
+        size_formatted = dc.formatBytes(totals.totalSize, true);
+        props.push([ 'Size', size_formatted ]);
+
+        props.push([ 'Files', totals.totalFiles ]);
+
+        totalsDiv.tabularexpandopanel({
+          title : "Snapshot Totals",
+          data : props
+        });
+      }).fail(function(err){
+        alert("Failed to retrieve snapshot totals.");
+      });
+    },
+
+    _getTotals: function() {
+        return dc.store.GetSnapshotTotals(
+            this._storeId,
+            'SNAPSHOT_COMPLETE');
     },
   }));
 

--- a/duradmin/src/main/webapp/js/spaces-manager.js
+++ b/duradmin/src/main/webapp/js/spaces-manager.js
@@ -2978,7 +2978,7 @@ $(function() {
     load : function(storeId) {
       this._storeId = storeId;
 
-      if (this._isAdmin())  {
+      if (this._isAdmin()) {
         if (this._isSnapshot(storeId)) {
             var totalsDiv = $.fn.create("div").addClass("totals-table");
             this._appendToCenter(totalsDiv);

--- a/snapshotdata/src/main/java/org/duracloud/snapshot/SnapshotConstants.java
+++ b/snapshotdata/src/main/java/org/duracloud/snapshot/SnapshotConstants.java
@@ -22,6 +22,8 @@ public class SnapshotConstants {
     public static final String CLEANUP_SNAPSHOT_TASK_NAME = "cleanup-snapshot";
     public static final String COMPLETE_SNAPSHOT_TASK_NAME = "complete-snapshot";
     public static final String GET_SNAPSHOTS_TASK_NAME = "get-snapshots";
+    public static final String GET_SNAPSHOTS_TOTALS_TASK_NAME = "get-snapshots-totals";
+
     public static final String GET_SNAPSHOT_TASK_NAME = "get-snapshot";
     public static final String GET_SNAPSHOT_CONTENTS_TASK_NAME = "get-snapshot-contents";
     public static final String GET_SNAPSHOT_HISTORY_TASK_NAME = "get-snapshot-history";

--- a/snapshotdata/src/main/java/org/duracloud/snapshot/dto/task/GetSnapshotsTotalsTaskParameters.java
+++ b/snapshotdata/src/main/java/org/duracloud/snapshot/dto/task/GetSnapshotsTotalsTaskParameters.java
@@ -1,0 +1,72 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.snapshot.dto.task;
+
+import java.io.IOException;
+import javax.xml.bind.annotation.XmlValue;
+
+import org.duracloud.common.json.JaxbJsonSerializer;
+import org.duracloud.snapshot.dto.BaseDTO;
+import org.duracloud.snapshot.error.SnapshotDataException;
+
+/**
+ * @author Nicholas Woodward
+ * Date: 7/26/21
+ */
+public class GetSnapshotsTotalsTaskParameters extends BaseDTO {
+
+    @XmlValue
+    private String status;
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    /**
+     * Creates a serialized version of task parameters
+     *
+     * @return JSON formatted task result info
+     */
+    public String serialize() {
+        JaxbJsonSerializer<GetSnapshotsTotalsTaskParameters> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotsTotalsTaskParameters.class);
+        try {
+            return serializer.serialize(this);
+        } catch (IOException e) {
+            throw new SnapshotDataException(
+                "Unable to create task parameters due to: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Parses properties from task parameter string
+     *
+     * @param taskParameters - JSON formatted set of parameters
+     */
+    public static GetSnapshotsTotalsTaskParameters deserialize(String taskParameters) {
+        JaxbJsonSerializer<GetSnapshotsTotalsTaskParameters> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotsTotalsTaskParameters.class);
+        try {
+            GetSnapshotsTotalsTaskParameters params =
+                serializer.deserialize(taskParameters);
+            // Verify expected parameters
+            if (null == params.getStatus() || params.getStatus().isEmpty()) {
+                throw new SnapshotDataException("Task parameter values may not be empty");
+            }
+            return params;
+        } catch (IOException e) {
+            throw new SnapshotDataException(
+                "Unable to parse task parameters due to: " + e.getMessage());
+        }
+    }
+
+}

--- a/snapshotdata/src/main/java/org/duracloud/snapshot/dto/task/GetSnapshotsTotalsTaskResult.java
+++ b/snapshotdata/src/main/java/org/duracloud/snapshot/dto/task/GetSnapshotsTotalsTaskResult.java
@@ -1,0 +1,45 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.snapshot.dto.task;
+
+import java.io.IOException;
+
+import org.duracloud.common.json.JaxbJsonSerializer;
+import org.duracloud.snapshot.dto.bridge.GetSnapshotTotalsBridgeResult;
+import org.duracloud.snapshot.error.SnapshotDataException;
+
+/**
+ * @author Nicholas Woodward
+ * Date: 7/26/21
+ */
+public class GetSnapshotsTotalsTaskResult extends GetSnapshotTotalsBridgeResult {
+
+    public GetSnapshotsTotalsTaskResult() {
+    }
+
+    public GetSnapshotsTotalsTaskResult(Long totalCount, Long totalSize, Long totalFiles) {
+        super(totalCount, totalSize, totalFiles);
+    }
+
+    /**
+     * Parses properties from task result
+     *
+     * @param taskResult - JSON formatted set of properties
+     */
+    public static GetSnapshotsTotalsTaskResult deserialize(String taskResult) {
+        JaxbJsonSerializer<GetSnapshotsTotalsTaskResult> serializer =
+            new JaxbJsonSerializer<>(GetSnapshotsTotalsTaskResult.class);
+        try {
+            return serializer.deserialize(taskResult);
+        } catch (IOException e) {
+            throw new SnapshotDataException(
+                "Unable to create task result due to: " + e.getMessage());
+        }
+    }
+
+}

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/SnapshotTaskProvider.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/SnapshotTaskProvider.java
@@ -21,6 +21,7 @@ import org.duracloud.snapshottask.snapshot.GetSnapshotContentsTaskRunner;
 import org.duracloud.snapshottask.snapshot.GetSnapshotHistoryTaskRunner;
 import org.duracloud.snapshottask.snapshot.GetSnapshotTaskRunner;
 import org.duracloud.snapshottask.snapshot.GetSnapshotsTaskRunner;
+import org.duracloud.snapshottask.snapshot.GetSnapshotsTotalsTaskRunner;
 import org.duracloud.snapshottask.snapshot.RequestRestoreSnapshotTaskRunner;
 import org.duracloud.snapshottask.snapshot.RestartSnapshotTaskRunner;
 import org.duracloud.snapshottask.snapshot.RestoreSnapshotTaskRunner;
@@ -84,6 +85,13 @@ public class SnapshotTaskProvider extends TaskProviderBase {
                                                 bridgeUser,
                                                 bridgePass,
                                                 snapshotProvider));
+        taskList.add(new GetSnapshotsTotalsTaskRunner(dcHost,
+                                                      dcStoreId,
+                                                      bridgeHost,
+                                                      bridgePort,
+                                                      bridgeUser,
+                                                      bridgePass,
+                                                      snapshotProvider));
         taskList.add(new GetSnapshotContentsTaskRunner(bridgeHost,
                                                        bridgePort,
                                                        bridgeUser,

--- a/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/snapshot/GetSnapshotsTotalsTaskRunner.java
+++ b/snapshotstorageprovider/src/main/java/org/duracloud/snapshottask/snapshot/GetSnapshotsTotalsTaskRunner.java
@@ -1,0 +1,97 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.snapshottask.snapshot;
+
+import java.text.MessageFormat;
+
+import org.duracloud.common.web.RestHttpHelper;
+import org.duracloud.snapshot.SnapshotConstants;
+import org.duracloud.snapshot.dto.task.GetSnapshotsTotalsTaskParameters;
+import org.duracloud.storage.error.TaskException;
+import org.duracloud.storage.provider.StorageProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Get total count, size and files of snapshots which are accessible to this account.
+ *
+ * @author Nicholas Woodward
+ * Date: 8/2/21
+ */
+public class GetSnapshotsTotalsTaskRunner extends AbstractSnapshotTaskRunner {
+
+    private Logger log = LoggerFactory.getLogger(GetSnapshotsTotalsTaskRunner.class);
+
+    private String dcHost;
+    private String dcStoreId;
+    private StorageProvider storageProvider;
+
+    public GetSnapshotsTotalsTaskRunner(String dcHost,
+                                        String dcStoreId,
+                                        String bridgeAppHost,
+                                        String bridgeAppPort,
+                                        String bridgeAppUser,
+                                        String bridgeAppPass,
+                                        StorageProvider storageProvider) {
+        super(bridgeAppHost, bridgeAppPort, bridgeAppUser, bridgeAppPass);
+        this.dcHost = dcHost;
+        this.dcStoreId = dcStoreId;
+        this.storageProvider = storageProvider;
+    }
+
+    @Override
+    public String getName() {
+        return SnapshotConstants.GET_SNAPSHOTS_TOTALS_TASK_NAME;
+    }
+
+    @Override
+    public String performTask(String taskParameters) {
+        GetSnapshotsTotalsTaskParameters taskParams =
+            GetSnapshotsTotalsTaskParameters.deserialize(taskParameters);
+
+        // get bridge results
+        String result = callBridge(createRestHelper(), buildBridgeURL(taskParams));
+
+        return result;
+    }
+
+    /*
+     * Create URL to call bridge app
+     */
+    protected String buildBridgeURL(GetSnapshotsTotalsTaskParameters taskParams) {
+        String status = taskParams.getStatus();
+
+        return MessageFormat.format("{0}/snapshot/total?host={1}&storeId={2}&status={3}",
+                                    buildBridgeBaseURL(),
+                                    dcHost,
+                                    dcStoreId,
+                                    status);
+    }
+
+    /*
+     * Calls the bridge application to get snapshot listing
+     */
+    protected String callBridge(RestHttpHelper restHelper, String bridgeURL) {
+        log.info("Making bridge call to get total count, size, and files of snapshots. URL: {}", bridgeURL);
+
+        try {
+            RestHttpHelper.HttpResponse response = restHelper.get(bridgeURL);
+            int statusCode = response.getStatusCode();
+            if (statusCode != 200) {
+                throw new RuntimeException("Unexpected response code: " +
+                                           statusCode);
+            }
+            return response.getResponseBody();
+        } catch (Exception e) {
+            throw new TaskException("Exception encountered attempting to " +
+                                    "get total count, size, and files of snapshots. " +
+                                    "Error reported: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/snapshotstorageprovider/src/test/java/org/duracloud/snapshottask/snapshot/GetSnapshotsTotalsTaskRunnerTest.java
+++ b/snapshotstorageprovider/src/test/java/org/duracloud/snapshottask/snapshot/GetSnapshotsTotalsTaskRunnerTest.java
@@ -1,0 +1,134 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.snapshottask.snapshot;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.InputStream;
+
+import org.duracloud.common.util.IOUtil;
+import org.duracloud.common.web.RestHttpHelper;
+import org.duracloud.snapshot.dto.bridge.GetSnapshotTotalsBridgeResult;
+import org.duracloud.snapshot.dto.task.GetSnapshotsTotalsTaskParameters;
+import org.duracloud.snapshot.dto.task.GetSnapshotsTotalsTaskResult;
+import org.duracloud.storage.error.TaskException;
+import org.duracloud.storage.provider.StorageProvider;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockSupport;
+import org.easymock.Mock;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Nicholas Woodward
+ * Date: 8/5/21
+ */
+@RunWith(EasyMockRunner.class)
+public class GetSnapshotsTotalsTaskRunnerTest extends EasyMockSupport {
+
+    @Mock(name = "RestHttpHelper")
+    private RestHttpHelper restHelper;
+    private GetSnapshotsTotalsTaskRunner taskRunner;
+    private StorageProvider storageProvider;
+    private String dcHost = "dc-host";
+    private String dcStoreId = "dc-store-id";
+    private String bridgeHost = "bridge-host";
+    private String bridgePort = "bridge-port";
+    private String bridgeUser = "bridge-user";
+    private String bridgePass = "bridge-pass";
+    private String status = "SNAPSHOT_COMPLETE";
+
+    @Before
+    public void setup() {
+
+        this.storageProvider = createMock("StorageProvider", StorageProvider.class);
+
+        taskRunner = new GetSnapshotsTotalsTaskRunner(dcHost, dcStoreId, bridgeHost, bridgePort,
+                                                bridgeUser, bridgePass, storageProvider) {
+            @Override
+            protected RestHttpHelper createRestHelper() {
+                return restHelper;
+            }
+        };
+    }
+
+    @After
+    public void tearDown() {
+        verifyAll();
+    }
+
+    @Test
+    public void testBuildSnapshotURL() {
+        replayAll();
+
+        GetSnapshotsTotalsTaskParameters taskParams = new GetSnapshotsTotalsTaskParameters();
+        taskParams.setStatus(status);
+
+        String snapshotUrl = taskRunner.buildBridgeURL(taskParams);
+
+        String expectedUrl = "http://" + bridgeHost + ":" + bridgePort +
+                             "/bridge/snapshot/total?host=" + dcHost + "&storeId=" + dcStoreId +
+                             "&status=" + status;
+        assertEquals(expectedUrl, snapshotUrl);
+    }
+
+    @Test
+    public void testCallBridgeSuccess() throws Exception {
+        String bridgeURL = "bridge-url";
+        String storeId = "store-id";
+        String spaceId = "space-id";
+
+        long totalCount = 1L;
+        long totalSize = 100L;
+        long totalFiles = 1000L;
+
+        GetSnapshotTotalsBridgeResult bridgeResult =
+            new GetSnapshotTotalsBridgeResult(totalCount, totalSize, totalFiles);
+        InputStream resultStream =
+            IOUtil.writeStringToStream(bridgeResult.serialize());
+
+        RestHttpHelper.HttpResponse response =
+            RestHttpHelper.HttpResponse.buildMock(200, null, resultStream);
+        EasyMock.expect(restHelper.get(bridgeURL))
+                .andReturn(response);
+
+        replayAll();
+
+        String callResult = taskRunner.callBridge(restHelper, bridgeURL);
+
+        GetSnapshotsTotalsTaskResult taskResult =
+            GetSnapshotsTotalsTaskResult.deserialize(callResult);
+
+        assertEquals(totalCount, taskResult.getTotalCount());
+        assertEquals(totalSize, taskResult.getTotalSize());
+        assertEquals(totalFiles, taskResult.getTotalFiles());
+    }
+
+    @Test
+    public void testCallBridgeFailure() throws Exception {
+        String bridgeURL = "bridge-url";
+
+        InputStream resultStream = IOUtil.writeStringToStream("Error");
+        RestHttpHelper.HttpResponse response =
+            RestHttpHelper.HttpResponse.buildMock(500, null, resultStream);
+        EasyMock.expect(restHelper.get(bridgeURL))
+                .andReturn(response);
+
+        replayAll();
+        try {
+            taskRunner.callBridge(restHelper, bridgeURL);
+            fail("Exception expected on 500 response");
+        } catch (TaskException e) {
+            // Expected exception
+        }
+    }
+}

--- a/storeclient/src/main/java/org/duracloud/client/task/SnapshotTaskClient.java
+++ b/storeclient/src/main/java/org/duracloud/client/task/SnapshotTaskClient.java
@@ -17,6 +17,7 @@ import org.duracloud.snapshot.dto.task.GetSnapshotContentsTaskResult;
 import org.duracloud.snapshot.dto.task.GetSnapshotHistoryTaskResult;
 import org.duracloud.snapshot.dto.task.GetSnapshotListTaskResult;
 import org.duracloud.snapshot.dto.task.GetSnapshotTaskResult;
+import org.duracloud.snapshot.dto.task.GetSnapshotsTotalsTaskResult;
 import org.duracloud.snapshot.dto.task.RequestRestoreSnapshotTaskResult;
 import org.duracloud.snapshot.dto.task.RestoreSnapshotTaskResult;
 
@@ -87,6 +88,16 @@ public interface SnapshotTaskClient {
      * @throws ContentStoreException on error
      */
     public GetSnapshotListTaskResult getSnapshots()
+        throws ContentStoreException;
+
+    /**
+     * Gets the total count, size (in bytes) and files of snapshots which are accessible to this account
+     *
+     * @param status
+     * @return results
+     * @throws ContentStoreException on error
+     */
+    public GetSnapshotsTotalsTaskResult getSnapshotsTotals(String status)
         throws ContentStoreException;
 
     /**

--- a/storeclient/src/main/java/org/duracloud/client/task/SnapshotTaskClientImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/task/SnapshotTaskClientImpl.java
@@ -27,6 +27,8 @@ import org.duracloud.snapshot.dto.task.GetSnapshotHistoryTaskResult;
 import org.duracloud.snapshot.dto.task.GetSnapshotListTaskResult;
 import org.duracloud.snapshot.dto.task.GetSnapshotTaskParameters;
 import org.duracloud.snapshot.dto.task.GetSnapshotTaskResult;
+import org.duracloud.snapshot.dto.task.GetSnapshotsTotalsTaskParameters;
+import org.duracloud.snapshot.dto.task.GetSnapshotsTotalsTaskResult;
 import org.duracloud.snapshot.dto.task.RequestRestoreSnapshotTaskResult;
 import org.duracloud.snapshot.dto.task.RestoreSnapshotTaskParameters;
 import org.duracloud.snapshot.dto.task.RestoreSnapshotTaskResult;
@@ -127,6 +129,26 @@ public class SnapshotTaskClientImpl implements SnapshotTaskClient {
             contentStore.performTask(SnapshotConstants.GET_SNAPSHOTS_TASK_NAME, "");
 
         return GetSnapshotListTaskResult.deserialize(taskResult);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GetSnapshotsTotalsTaskResult getSnapshotsTotals(String status)
+        throws ContentStoreException {
+        if (null == status) {
+            status = "SNAPSHOT_COMPLETE";
+        }
+
+        GetSnapshotsTotalsTaskParameters taskParams =
+            new GetSnapshotsTotalsTaskParameters();
+        taskParams.setStatus(status);
+
+        String taskResult =
+            contentStore.performTask(SnapshotConstants.GET_SNAPSHOTS_TOTALS_TASK_NAME, taskParams.serialize());
+
+        return GetSnapshotsTotalsTaskResult.deserialize(taskResult);
     }
 
     /**

--- a/storeclient/src/main/java/org/duracloud/client/task/SnapshotTaskClientImpl.java
+++ b/storeclient/src/main/java/org/duracloud/client/task/SnapshotTaskClientImpl.java
@@ -10,6 +10,7 @@ package org.duracloud.client.task;
 import org.duracloud.client.ContentStore;
 import org.duracloud.error.ContentStoreException;
 import org.duracloud.snapshot.SnapshotConstants;
+import org.duracloud.snapshot.dto.SnapshotStatus;
 import org.duracloud.snapshot.dto.task.CleanupSnapshotTaskParameters;
 import org.duracloud.snapshot.dto.task.CleanupSnapshotTaskResult;
 import org.duracloud.snapshot.dto.task.CompleteRestoreTaskParameters;
@@ -138,7 +139,7 @@ public class SnapshotTaskClientImpl implements SnapshotTaskClient {
     public GetSnapshotsTotalsTaskResult getSnapshotsTotals(String status)
         throws ContentStoreException {
         if (null == status) {
-            status = "SNAPSHOT_COMPLETE";
+            status = SnapshotStatus.SNAPSHOT_COMPLETE.name();
         }
 
         GetSnapshotsTotalsTaskParameters taskParams =

--- a/storeclient/src/test/java/org/duracloud/client/task/SnapshotTaskClientImplTest.java
+++ b/storeclient/src/test/java/org/duracloud/client/task/SnapshotTaskClientImplTest.java
@@ -8,6 +8,7 @@
 package org.duracloud.client.task;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import org.duracloud.snapshot.dto.task.GetSnapshotContentsTaskResult;
 import org.duracloud.snapshot.dto.task.GetSnapshotHistoryTaskResult;
 import org.duracloud.snapshot.dto.task.GetSnapshotListTaskResult;
 import org.duracloud.snapshot.dto.task.GetSnapshotTaskResult;
+import org.duracloud.snapshot.dto.task.GetSnapshotsTotalsTaskResult;
 import org.duracloud.snapshot.dto.task.RequestRestoreSnapshotTaskResult;
 import org.duracloud.snapshot.dto.task.RestoreSnapshotTaskResult;
 import org.easymock.EasyMock;
@@ -67,6 +69,7 @@ public class SnapshotTaskClientImplTest {
     private String completionResult = "result";
     private String historyValue = "history";
     private int daysToExpire = 30;
+    private String status = "SNAPSHOT_COMPLETE";
 
     @Before
     public void setup() {
@@ -194,6 +197,27 @@ public class SnapshotTaskClientImplTest {
         assertThat(storeId, equalTo(resultSummary.getSourceStoreId()));
         assertThat(spaceId, equalTo(resultSummary.getSourceSpaceId()));
 
+    }
+
+    @Test
+    public void testGetSnapshotsTotals() throws Exception {
+        String taskName = SnapshotConstants.GET_SNAPSHOTS_TOTALS_TASK_NAME;
+
+        long totalCount = 1L;
+        long totalSize = 100L;
+        long totalFiles = 1000L;
+
+        GetSnapshotsTotalsTaskResult preparedResult =
+            new GetSnapshotsTotalsTaskResult(totalCount, totalSize, totalFiles);
+
+        setupMock(taskName, preparedResult.serialize());
+        replayMocks();
+
+        GetSnapshotsTotalsTaskResult result = taskClient.getSnapshotsTotals(status);
+
+        assertEquals(totalCount, result.getTotalCount());
+        assertEquals(totalSize, result.getTotalSize());
+        assertEquals(totalFiles, result.getTotalFiles());
     }
 
     @Test


### PR DESCRIPTION
**This PR builds on the work of [DURACLOUD-1150](https://github.com/duracloud/duracloud/pull/148) to present information about snapshots (total count, size and files) in the UI.**
* * *

**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1279

* https://duracloud.atlassian.net/browse/DURACLOUD-1150
* https://github.com/duracloud/snapshot/pull/30

# What does this Pull Request do?
This PR adds a snapshot totals pane to the GUI for snapshot storage providers when no spaces are selected. It uses the API calls added in DURACLOUD-1150 to get the statistics. 

# How should this be tested?
* Deploy DuraCloud and select a storage provider such as Chronopolis to see the stats
* Compare the values with what's in your Bridge's database, substituting your host for $HOST:
   * `SELECT COUNT(id) FROM snapshot WHERE host = '$HOST' AND status = 'SNAPSHOT_COMPLETE';`
   * `SELECT SUM(total_size_in_bytes) FROM snapshot WHERE host = '$HOST' AND status = 'SNAPSHOT_COMPLETE';`
   * `SELECT COUNT(sci.id) FROM snapshot s LEFT JOIN snapshot_content_item sci ON s.id = sci.snapshot_id WHERE s.host = '$HOST' AND s.status = 'SNAPSHOT_COMPLETE';`

# Interested parties
Tag @duracloud/committers
