### PR TITLE
DURACLOUD-1317: Updates xstream dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -682,7 +682,7 @@
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.17</version>
+        <version>1.4.18</version>
       </dependency>
 
       <dependency>

--- a/synctoolui/src/main/java/org/duracloud/syncui/service/RuntimeStateMemento.java
+++ b/synctoolui/src/main/java/org/duracloud/syncui/service/RuntimeStateMemento.java
@@ -56,7 +56,10 @@ public class RuntimeStateMemento {
             try (InputStream is = new FileInputStream(stateFile)) {
                 log.debug("retrieving state from {}",
                           stateFile.getAbsolutePath());
+
                 XStream xstream = new XStream();
+                xstream.allowTypes(new Class[] {RuntimeStateMemento.class});
+
                 //FileInputStream fis = new FileInputStream(stateFile);
                 return (RuntimeStateMemento) xstream.fromXML(is);
             } catch (IOException e) {

--- a/synctoolui/src/main/java/org/duracloud/syncui/service/SyncToolConfigSerializer.java
+++ b/synctoolui/src/main/java/org/duracloud/syncui/service/SyncToolConfigSerializer.java
@@ -40,6 +40,7 @@ public class SyncToolConfigSerializer {
     }
 
     private static void configure(XStream xstream) {
+        xstream.allowTypes(new Class[] {SyncToolConfig.class});
         xstream.alias("syncToolConfig", SyncToolConfig.class);
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1317

# What does this Pull Request do?

Updates the xstream dependency to version 1.4.18 due to a security notice in 1.4.17.

# How should this be tested?

There are no functional changes. So long as the application continues to work, we're good.