### PR TITLE
DURACLOUD-1278: Adds Github Actions build to replace Travis CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,7 +38,7 @@ jobs:
 
     # Run build and execute tests
     - name: Build and Run unit tests
-      run: mvn clean install -DskipIntTests --batch-mode
+      run: mvn clean install -DskipIntTests -DskipDeploy --batch-mode
 
     # https://github.com/actions/setup-java
     # Sets up Java again, preparing the settings.xml to deploy to Sonatype (Maven)
@@ -70,7 +70,7 @@ jobs:
     # Execute deployment to sonatype (only on push to develop or master branches)
     - name: Publish to Sonatype
       if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
-      run: mvn deploy -DreleaseBuild -DskipTests --batch-mode
+      run: mvn deploy -DreleaseBuild -DskipTests -DskipDeploy --batch-mode
       env:
         SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
         SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,113 @@
+# Continuous Integration Build via GitHub Actions
+name: CI Build
+
+# Run this Build for all pushes and PRs
+on: [push, pull_request]
+
+jobs:
+  ci-build:
+    runs-on: ubuntu-latest
+    env:
+      # Specify memory for Maven
+      MAVEN_OPTS: "-Xmx256M"
+    steps:
+    # Output current build environment
+    - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
+    - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
+
+    # https://github.com/actions/checkout
+    - name: Checkout codebase
+      uses: actions/checkout@v2
+
+    # https://github.com/actions/setup-java
+    - name: Install JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: 11
+        distribution: adopt
+
+    # https://github.com/actions/cache
+    - name: Cache Maven dependencies
+      uses: actions/cache@v2
+      with:
+        # Cache entire ~/.m2/repository
+        path: ~/.m2/repository
+        # Cache key is hash of all pom.xml files. Therefore any changes to POMs will invalidate cache
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
+
+    # Run build and execute tests
+    - name: Build and Run unit tests
+      run: mvn clean install -DskipIntTests --batch-mode
+
+    # https://github.com/actions/setup-java
+    # Sets up Java again, preparing the settings.xml to deploy to Sonatype (Maven)
+    # ONLY on push to develop branch (using Sonatype snapshots repo)
+    - name: Set up for deploy to Sonatype
+      uses: actions/setup-java@v2
+      if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+      with:
+        java-version: 11
+        distribution: adopt
+        server-id: sonatype-snapshots # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: SONATYPE_USERNAME # env variable for sonatype username
+        server-password: SONATYPE_PASSWORD # env variable for sonatype password
+        gpg-private-key: ${{ secrets.CODESIGN_GPG_KEY }} # Value of the GPG private key to import
+        gpg-passphrase: CODESIGN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+    # ONLY on push to master branch (using Sonatype releases repo)
+    - name: Set up for deploy to Sonatype
+      uses: actions/setup-java@v2
+      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      with:
+        java-version: 11
+        distribution: adopt
+        server-id: sonatype-releases # Value of the distributionManagement/repository/id field of the pom.xml
+        server-username: SONATYPE_USERNAME # env variable for sonatype username
+        server-password: SONATYPE_PASSWORD # env variable for sonatype password
+        gpg-private-key: ${{ secrets.CODESIGN_GPG_KEY }} # Value of the GPG private key to import
+        gpg-passphrase: CODESIGN_GPG_PASSPHRASE # env variable for GPG private key passphrase
+
+    # Execute deployment to sonatype (only on push to develop or master branches)
+    - name: Publish to Sonatype
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+      run: mvn deploy -DreleaseBuild -DskipTests --batch-mode
+      env:
+        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        CODESIGN_GPG_PASSPHRASE: ${{ secrets.CODESIGN_GPG_PASSPHRASE }}
+
+    # https://github.com/marketplace/actions/send-email
+    - name: Send result email
+      uses: dawidd6/action-send-mail@v3
+      if: always()
+      with:
+        # smtp settings
+        server_address: ${{ secrets.SMTP_SERVER_HOST }}
+        server_port: ${{ secrets.SMTP_SERVER_PORT }}
+        username: ${{ secrets.SMTP_USERNAME }}
+        password: ${{ secrets.SMTP_PASSWORD }}
+        secure: true
+        # email subject
+        subject: CI build for ${{ github.repository }} result - ${{ job.status }}
+        # email body
+        body: >
+          A CI Build in ${{ github.repository }} was triggerd by a ${{ github.event_name }} event on
+          branch (or tag) ${{ github.ref }}.
+
+          The result was: ${{ job.status }}
+
+          More details are available here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        # to emails (comma-separated string)
+        to: cibuilds@duracloud.org
+        # from email
+        from: DuraCloud CI Builder <notifications@duracloud.org>
+
+    # https://github.com/marketplace/actions/action-slack
+    - name: Send slack alert on failure
+      uses: 8398a7/action-slack@v3
+      if: failure()
+      with:
+        status: ${{ job.status }}
+        fields: repo,message,commit,author,eventName,workflow,ref,took
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,10 +54,10 @@ jobs:
         server-password: SONATYPE_PASSWORD # env variable for sonatype password
         gpg-private-key: ${{ secrets.CODESIGN_GPG_KEY }} # Value of the GPG private key to import
         gpg-passphrase: CODESIGN_GPG_PASSPHRASE # env variable for GPG private key passphrase
-    # ONLY on push to master branch (using Sonatype releases repo)
+    # ONLY on push to main branch (using Sonatype releases repo)
     - name: Set up for deploy to Sonatype
       uses: actions/setup-java@v2
-      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       with:
         java-version: 11
         distribution: adopt
@@ -67,9 +67,9 @@ jobs:
         gpg-private-key: ${{ secrets.CODESIGN_GPG_KEY }} # Value of the GPG private key to import
         gpg-passphrase: CODESIGN_GPG_PASSPHRASE # env variable for GPG private key passphrase
 
-    # Execute deployment to sonatype (only on push to develop or master branches)
+    # Execute deployment to sonatype (only on push to develop or main branches)
     - name: Publish to Sonatype
-      if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/master')
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')
       run: mvn deploy -DreleaseBuild -DskipTests -DskipDeploy --batch-mode
       env:
         SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>3.0.1</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>


### PR DESCRIPTION
**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1278

# What does this Pull Request do?

Adds a build of the DuraCloud application executed by Github Actions. On failure a notice is set to Slack. On success or failure an email notification is sent. When the build is run on the develop or main branch the result is pushed to Sonatype.

# How should this be tested?

A build should be run and available to view in Github for each commit in this PR. When the PR is merged, it should run a build on develop.

# Additional Notes:

This PR leaves the Travis CI configuration in place to serve as reference when adding a Github Action to capture release artifacts.
