### PR TITLE
Fixes issue with EB health checker falsely reporting severe status

### DIFF
--- a/resources/beanstalk/.platform/httpd/conf.d/elasticbeanstalk.conf
+++ b/resources/beanstalk/.platform/httpd/conf.d/elasticbeanstalk.conf
@@ -15,6 +15,7 @@
 
   RewriteEngine On
   RewriteCond %{HTTP:X-Forwarded-Proto} !https
+  RewriteCond %{HTTP_USER_AGENT} !ELB-HealthChecker
   RewriteRule !/status https://%{SERVER_NAME}%{REQUEST_URI} [L,R]
 
   ErrorLog /var/log/httpd/elasticbeanstalk-error_log


### PR DESCRIPTION
Sample Elastic Beanstalk config – https://github.com/awsdocs/elastic-beanstalk-samples/blob/main/configuration-files/aws-provided/security-configuration/https-redirect/java-tomcat/https-redirect-java-tomcat-apache-2.4/httpd/conf.d/elasticbeanstalk.conf

# Interested parties
@duracloud/committers
