### PR TITLE
Tells spring security to allow URLs with percent and semicolon characters

### DIFF
--- a/duradmin/src/main/webapp/WEB-INF/config/security-config.xml
+++ b/duradmin/src/main/webapp/WEB-INF/config/security-config.xml
@@ -100,5 +100,11 @@
   <beans:bean id="webexpressionHandler"
               class="org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler"/>
 
+  <beans:bean id="allowCharactersHttpFirewall"
+              class="org.springframework.security.web.firewall.StrictHttpFirewall">
+    <beans:property name="allowUrlEncodedPercent" value="true"/>
+    <beans:property name="allowSemicolon" value="true"/>
+  </beans:bean>
+  <http-firewall ref="allowCharactersHttpFirewall"/>
 
 </beans:beans>

--- a/durastore/src/main/webapp/WEB-INF/config/security-config.xml
+++ b/durastore/src/main/webapp/WEB-INF/config/security-config.xml
@@ -122,4 +122,11 @@
     <beans:constructor-arg value="256"/>
   </beans:bean>
 
+  <beans:bean id="allowCharactersHttpFirewall"
+              class="org.springframework.security.web.firewall.StrictHttpFirewall">
+    <beans:property name="allowUrlEncodedPercent" value="true"/>
+    <beans:property name="allowSemicolon" value="true"/>
+  </beans:bean>
+  <http-firewall ref="allowCharactersHttpFirewall"/>
+
 </beans:beans>


### PR DESCRIPTION
# What does this Pull Request do?

The update to Spring Security 4.2 introduced the default usage of StrictHttpFirewall. This PR adjusts those default settings to allow percent and semicolon characters to be included in valid calls to the DuraCloud UI and REST API.

# How should this be tested?

Add content to DuraCloud that includes percent and semicolon symbols in the content ID. Ensure that the content can be retrieved and used without error.
