### PR TITLE
Add CONTENT_RANGE as a permissible Swift header

### DIFF
--- a/swiftstorageprovider/src/main/java/org/duracloud/swiftstorage/SwiftStorageProvider.java
+++ b/swiftstorageprovider/src/main/java/org/duracloud/swiftstorage/SwiftStorageProvider.java
@@ -60,8 +60,14 @@ public class SwiftStorageProvider extends S3StorageProvider {
         super(s3Client, accessKey, null);
     }
 
-    private static String[] SWIFT_METADATA_LIST =
-        {Headers.ETAG, Headers.CONTENT_LENGTH, Headers.DATE, Headers.LAST_MODIFIED, Headers.CONTENT_TYPE};
+    private static String[] SWIFT_METADATA_LIST = {
+        Headers.ETAG,
+        Headers.CONTENT_LENGTH,
+        Headers.CONTENT_TYPE,
+        Headers.CONTENT_RANGE,
+        Headers.DATE,
+        Headers.LAST_MODIFIED,
+    };
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Omitting this header was causing integration tests to fail, so Adding it
as an allowed header for the SwiftS3 storage provider.

# How should this be tested?

* Run integration tests against a build before this change. Observe that the integration tests fail.
* Build with this change and run integration tests again. Observe that the integration tests succeed.
* Observe that the metadata list in the UI is unaffected.

# Interested parties
@duracloud/committers
