### PR TITLE
Increases sonatype upload timeout.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,7 @@
           <!-- Ensures all artifacts are staged together in the same repo -->
           <stagingProfileId>4f035a66af3dde</stagingProfileId>
           <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
The default is 5 minutes.   I noticed that this timeout was being exceeded on occasion during the release process so I bumped it up to 10 minutes.