### PR TITLE
DURACLOUD-1333: Change cookie specification to STANDARD to accommodate more date formats

### DIFF
--- a/common/src/main/java/org/duracloud/common/web/RestHttpHelper.java
+++ b/common/src/main/java/org/duracloud/common/web/RestHttpHelper.java
@@ -25,6 +25,8 @@ import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
@@ -338,6 +340,9 @@ public class RestHttpHelper {
         if (method.equals(Method.HEAD)) {
             builder.disableContentCompression();
         }
+
+        // Set CookieSpec to STANDARD for RFC 6265 compliant policy
+        builder.setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build());
 
         return builder.build();
     }


### PR DESCRIPTION
**This PR changes the cookie specification in the HTTP Client from DEFAULT to STANDARD in order to prevent warnings about the format of the date in cookies sent from the AWS Application Load Balancer.**
* * *

**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1333

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
A in-depth description of the changes made by this PR. Technical details and possible side effects.

# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# Interested parties
@duracloud/committers
