### PR TITLE
Put sumo_sources.json in the /opt/ dir

### DIFF
--- a/resources/beanstalk/.ebextensions/sumo_logic.config
+++ b/resources/beanstalk/.ebextensions/sumo_logic.config
@@ -16,7 +16,7 @@ services:
         - /etc/sumo.conf
 
 files:
-  "/etc/sumo_sources.json":
+  "/opt/sumo_sources.json":
     mode: "000755"
     owner: root
     group: root


### PR DESCRIPTION
 This update ensures the sumo sources json is being placed in the /opt/dir directory by the beanstalk configuration.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
