### PR TITLE
Retrieval Tool: Indicates "complete" before all transfers finish

### DIFF
--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalManager.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalManager.java
@@ -8,6 +8,8 @@
 package org.duracloud.retrieval.mgmt;
 
 import java.io.File;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Phaser;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -40,6 +42,7 @@ public class RetrievalManager implements Runnable {
     private boolean createSpaceDir;
     private boolean applyTimestamps;
     private boolean complete;
+    private Phaser phaser;
 
     public RetrievalManager(RetrievalSource source,
                             File contentDir,
@@ -57,6 +60,7 @@ public class RetrievalManager implements Runnable {
         this.outWriter = outWriter;
         this.createSpaceDir = createSpaceDir;
         this.applyTimestamps = applyTimestamps;
+        this.phaser = new Phaser();
 
         // Create thread pool for retrieval workers
         workerPool =
@@ -72,6 +76,7 @@ public class RetrievalManager implements Runnable {
      * Begins the content retrieval process
      */
     public void run() {
+        phaser.register();
 
         try {
             while (!complete) {
@@ -113,9 +118,12 @@ public class RetrievalManager implements Runnable {
                                                          outWriter,
                                                          createSpaceDir,
                                                          applyTimestamps);
-            workerPool.execute(worker);
+            phaser.register();
+            CompletableFuture.runAsync(worker, workerPool)
+                             .thenRun(phaser::arriveAndDeregister);
             return true;
         } catch (RejectedExecutionException e) {
+            phaser.arriveAndDeregister();
             return false;
         }
     }
@@ -128,11 +136,7 @@ public class RetrievalManager implements Runnable {
         logger.info("Closing Retrieval Manager");
         workerPool.shutdown();
 
-        try {
-            workerPool.awaitTermination(30, TimeUnit.MINUTES);
-        } catch (InterruptedException e) {
-            // Exit wait on interruption
-        }
+        phaser.arriveAndAwaitAdvance();
 
         complete = true;
     }

--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalManager.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/RetrievalManager.java
@@ -136,6 +136,7 @@ public class RetrievalManager implements Runnable {
         logger.info("Closing Retrieval Manager");
         workerPool.shutdown();
 
+        logger.info("Waiting for retrievals to complete, this may take some time...");
         phaser.arriveAndAwaitAdvance();
 
         complete = true;


### PR DESCRIPTION
**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1069

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This updates the shutdown logic of the RetrievalManager to use a phaser to track work completion instead of using awaitTermination.

# How should this be tested?

* Rebuild the retrieval tool
* Run the tool on a large-ish space
* When the final status message is printed there should no longer be any retrievals in progress

# Additional Notes:
I was considering using `submit` to return a future and do a get on each to emulate joining the threads, but wasn't sure what the typical space would look like and didn't want a growing list of futures. Not a big deal just an alternate solution which might be a _little_ bit simpler. 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
