### PR TITLE
Update the sonatype publish and signing routines to use java 17

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -47,7 +47,7 @@ jobs:
       uses: actions/setup-java@v2
       if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
       with:
-        java-version: 11
+        java-version: 17
         distribution: adopt
         server-id: sonatype-snapshots # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: SONATYPE_USERNAME # env variable for sonatype username
@@ -59,7 +59,7 @@ jobs:
       uses: actions/setup-java@v2
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       with:
-        java-version: 11
+        java-version: 17
         distribution: adopt
         server-id: sonatype-releases # Value of the distributionManagement/repository/id field of the pom.xml
         server-username: SONATYPE_USERNAME # env variable for sonatype username


### PR DESCRIPTION
This is a follow to the recent java 17 updates (missed a couple of java 11 references).