### PR TITLE
[DURACLOUD-1342] Enable access control lists on buckets by default

### DIFF
--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
@@ -7,6 +7,7 @@
  */
 package org.duracloud.s3storage;
 
+import static java.util.Arrays.asList;
 import static org.apache.http.HttpHeaders.CONTENT_ENCODING;
 import static org.duracloud.storage.error.StorageException.NO_RETRY;
 import static org.duracloud.storage.error.StorageException.RETRY;
@@ -18,6 +19,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -25,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import ch.qos.logback.core.net.ObjectWriter;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.Headers;
@@ -36,16 +39,23 @@ import com.amazonaws.services.s3.model.BucketTaggingConfiguration;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
 import com.amazonaws.services.s3.model.CopyObjectResult;
+import com.amazonaws.services.s3.model.DeletePublicAccessBlockRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PublicAccessBlockConfiguration;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectResult;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.services.s3.model.SetBucketOwnershipControlsRequest;
+import com.amazonaws.services.s3.model.SetPublicAccessBlockRequest;
 import com.amazonaws.services.s3.model.StorageClass;
 import com.amazonaws.services.s3.model.TagSet;
+import com.amazonaws.services.s3.model.ownership.ObjectOwnership;
+import com.amazonaws.services.s3.model.ownership.OwnershipControls;
+import com.amazonaws.services.s3.model.ownership.OwnershipControlsRule;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpStatus;
 import org.duracloud.common.model.AclType;
@@ -235,6 +245,18 @@ public class S3StorageProvider extends StorageProviderBase {
             created = new Date();
         }
 
+        // enable ACLs
+        final var bucketName = bucket.getName();
+        s3Client.deletePublicAccessBlock(new DeletePublicAccessBlockRequest()
+            .withBucketName(bucketName));
+
+        final var rule = new OwnershipControlsRule().withOwnership(ObjectOwnership.ObjectWriter);
+        final var ownershipControls = new OwnershipControls().withRules(asList(rule));
+
+        s3Client.setBucketOwnershipControls(new SetBucketOwnershipControlsRequest()
+            .withBucketName(bucketName)
+            .withOwnershipControls(ownershipControls));
+
         // Empty ACL set for new space (no permissions set)
         Map<String, AclType> spaceACLs = new HashMap<>();
 
@@ -285,17 +307,17 @@ public class S3StorageProvider extends StorageProviderBase {
     public String createHiddenSpace(String spaceId, int expirationInDays) {
         String bucketName = getHiddenBucketName(spaceId);
         try {
-            Bucket bucket = s3Client.createBucket(bucketName);
+            final Bucket bucket = s3Client.createBucket(bucketName);
 
             // Apply lifecycle config to bucket
 
-            BucketLifecycleConfiguration.Rule expiresRule = new BucketLifecycleConfiguration.Rule()
+            final BucketLifecycleConfiguration.Rule expiresRule = new BucketLifecycleConfiguration.Rule()
                 .withId("ExpirationRule")
                 .withExpirationInDays(expirationInDays)
                 .withStatus(BucketLifecycleConfiguration.ENABLED);
 
             // Add the rules to a new BucketLifecycleConfiguration.
-            BucketLifecycleConfiguration configuration = new BucketLifecycleConfiguration()
+            final BucketLifecycleConfiguration configuration = new BucketLifecycleConfiguration()
                 .withRules(expiresRule);
 
             s3Client.setBucketLifecycleConfiguration(bucketName, configuration);


### PR DESCRIPTION
**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: https://github.com/duracloud/duracloud/pull/new/DURACLOUD-1342-enable-access-control-lists

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
The bridge makes calls to DuraCloud API that require access control based authorization.  AWS changed their default bucket policy a short time ago to turn off all access control list based authn by default.  This change simply restores the default behavior before AWS's policy change.

# How should this be tested?
Unit tests covered.  Should be deployed to a dev environment and tested by verifying that "all public access" is unblocked and  the bucket's access control list based authn is enabled.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
