### PR TITLE
Duracloud 1349 retrieval tests fix

### DIFF
--- a/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/SpaceListWorker.java
+++ b/retrievaltool/src/main/java/org/duracloud/retrieval/mgmt/SpaceListWorker.java
@@ -71,7 +71,7 @@ public class SpaceListWorker implements Runnable {
                                                   providerType + "-" + DateUtil.nowPlain() + ".txt");
             }
 
-            System.out.println("Writing space '" + spaceId + "' listing to: " +
+            logger.info("Writing space '" + spaceId + "' listing to: " +
                                outputFile.getAbsolutePath());
             Iterator<String> contentIterator = contentStore.getSpaceContents(spaceId);
             try (Writer writer = new BufferedWriter(new OutputStreamWriter(

--- a/retrievaltool/src/test/java/org/duracloud/retrieval/RetrievalTestBase.java
+++ b/retrievaltool/src/test/java/org/duracloud/retrieval/RetrievalTestBase.java
@@ -11,7 +11,6 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.duracloud.common.model.ContentItem;
 import org.duracloud.retrieval.mgmt.OutputWriter;
 import org.easymock.EasyMock;
@@ -28,7 +27,7 @@ public abstract class RetrievalTestBase {
 
     @Before
     public void setUp() throws Exception {
-        tempDir = new File("target/" + this.getClass().getName() + RandomStringUtils.random(10));
+        tempDir = new File("target/" + this.getClass().getName());
         tempDir.mkdir();
     }
 
@@ -52,7 +51,7 @@ public abstract class RetrievalTestBase {
     }
 
     protected File createTempFile(String prefix) throws IOException {
-        final var file = new File(this.tempDir, prefix + RandomStringUtils.random(20) + ".tmp");
+        final var file = new File(this.tempDir, prefix + ".tmp");
         return file;
     }
 }

--- a/retrievaltool/src/test/java/org/duracloud/retrieval/RetrievalTestBase.java
+++ b/retrievaltool/src/test/java/org/duracloud/retrieval/RetrievalTestBase.java
@@ -8,8 +8,10 @@
 package org.duracloud.retrieval;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.duracloud.common.model.ContentItem;
 import org.duracloud.retrieval.mgmt.OutputWriter;
 import org.easymock.EasyMock;
@@ -26,7 +28,7 @@ public abstract class RetrievalTestBase {
 
     @Before
     public void setUp() throws Exception {
-        tempDir = new File("target/" + this.getClass().getName());
+        tempDir = new File("target/" + this.getClass().getName() + RandomStringUtils.random(10));
         tempDir.mkdir();
     }
 
@@ -38,14 +40,19 @@ public abstract class RetrievalTestBase {
     protected OutputWriter createMockOutputWriter() {
         OutputWriter outWriter = EasyMock.createMock(OutputWriter.class);
         outWriter.writeSuccess(EasyMock.isA(ContentItem.class),
-                               EasyMock.isA(String.class),
-                               EasyMock.anyInt());
+            EasyMock.isA(String.class),
+            EasyMock.anyInt());
         EasyMock.expectLastCall().anyTimes();
         outWriter.writeFailure(EasyMock.isA(ContentItem.class),
-                               EasyMock.isA(String.class),
-                               EasyMock.anyInt());
+            EasyMock.isA(String.class),
+            EasyMock.anyInt());
         EasyMock.expectLastCall().anyTimes();
         EasyMock.replay(outWriter);
         return outWriter;
+    }
+
+    protected File createTempFile(String prefix) throws IOException {
+        final var file = new File(this.tempDir, prefix + RandomStringUtils.random(20) + ".tmp");
+        return file;
     }
 }

--- a/retrievaltool/src/test/java/org/duracloud/retrieval/mgmt/RetrievalWorkerTest.java
+++ b/retrievaltool/src/test/java/org/duracloud/retrieval/mgmt/RetrievalWorkerTest.java
@@ -7,16 +7,17 @@
  */
 package org.duracloud.retrieval.mgmt;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
@@ -143,7 +144,7 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
     @Test
     public void testChecksumsMatch() throws Exception {
         RetrievalWorker worker = createRetrievalWorker(true);
-        File localFile = new File(tempDir, "checksum-test");
+        File localFile = createTempFile("checksum-test");
 
         FileUtils.writeStringToFile(localFile, contentValue);
         assertTrue(worker.checksumsMatch(localFile));
@@ -155,7 +156,7 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
     @Test
     public void testRenameFile() throws Exception {
         RetrievalWorker worker = createRetrievalWorker(true);
-        File localFile = new File(tempDir, "rename-test");
+        File localFile = createTempFile("rename-test");
         String localFilePath = localFile.getAbsolutePath();
         FileUtils.writeStringToFile(localFile, "test");
 
@@ -165,7 +166,7 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
         assertTrue(newFile.exists());
 
         assertEquals(localFile.getAbsolutePath() + "-copy",
-                     newFile.getAbsolutePath());
+            newFile.getAbsolutePath());
 
         FileUtils.writeStringToFile(localFile, "test");
         File newFile2 = worker.renameFile(localFile);
@@ -174,13 +175,13 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
         assertTrue(newFile2.exists());
 
         assertEquals(localFile.getAbsolutePath() + "-copy-2",
-                     newFile2.getAbsolutePath());
+            newFile2.getAbsolutePath());
     }
 
     @Test
     public void testDeleteFile() throws Exception {
         RetrievalWorker worker = createRetrievalWorker(true);
-        File localFile = new File(tempDir, "rename-test");
+        File localFile = createTempFile("rename-test");
         FileUtils.writeStringToFile(localFile, "test");
 
         worker.deleteFile(localFile);
@@ -190,9 +191,8 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
     @Test
     public void testRetrieveToFile() throws Exception {
         RetrievalWorker worker = createRetrievalWorker(true);
-        File localFile = new File(tempDir, "retrieve-to-file-test");
+        File localFile = createTempFile("retrieve-to-file-test");
         assertFalse(localFile.exists());
-
         worker.retrieveToFile(localFile, null);
         assertTrue(localFile.exists());
 
@@ -209,8 +209,7 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
 
         // Test failure
         worker = createBrokenRetrievalWorker(true);
-        localFile = new File(tempDir, "retrieve-to-file-failure-test");
-        assertFalse(localFile.exists());
+        localFile = createTempFile("retrieve-to-file-failure-test");
 
         try {
             worker.retrieveToFile(localFile, null);
@@ -233,8 +232,9 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
         ContentStream content =
             new ContentStream(null, props);
 
-        File localFile = new File(tempDir, "timestamp-test");
-        FileUtils.writeStringToFile(localFile, contentValue);
+        File localFile = createTempFile("timestamp-test");
+        assertFalse(localFile.exists());
+        FileUtils.writeStringToFile(localFile, contentValue, Charset.defaultCharset());
 
         // Check that initial timestamps are current
         BasicFileAttributes fileAttributes =
@@ -258,7 +258,7 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
         assertFalse(isTimeClose(lastAccessTime, now));
         assertFalse(isTimeClose(lastModifiedTime, now));
         assertTrue(testTime + 100000 == creationTime || // windows
-                   testTime + 300000 == creationTime);  // linux
+            testTime + 300000 == creationTime);  // linux
         assertEquals(testTime + 200000, lastAccessTime);
         assertEquals(testTime + 300000, lastModifiedTime);
     }
@@ -270,42 +270,42 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
 
     private RetrievalWorker createRetrievalWorker(boolean overwrite) {
         return new RetrievalWorker(new ContentItem(spaceId, contentId),
-                                   new MockRetrievalSource(),
-                                   tempDir,
-                                   overwrite,
-                                   createMockOutputWriter(),
-                                   true,
-                                   true);
+            new MockRetrievalSource(),
+            tempDir,
+            overwrite,
+            createMockOutputWriter(),
+            true,
+            true);
     }
 
     private RetrievalWorker createRetrievalWorkerSingleSpace(boolean overwrite) {
         return new RetrievalWorker(new ContentItem(spaceId, contentId),
-                                   new MockRetrievalSource(),
-                                   tempDir,
-                                   overwrite,
-                                   createMockOutputWriter(),
-                                   false,
-                                   false);
+            new MockRetrievalSource(),
+            tempDir,
+            overwrite,
+            createMockOutputWriter(),
+            false,
+            false);
     }
 
     private RetrievalWorker createBrokenRetrievalWorker(boolean overwrite) {
         return new RetrievalWorker(new ContentItem(spaceId, contentId),
-                                   new BrokenMockRetrievalSource(),
-                                   tempDir,
-                                   overwrite,
-                                   createMockOutputWriter(),
-                                   true,
-                                   false);
+            new BrokenMockRetrievalSource(),
+            tempDir,
+            overwrite,
+            createMockOutputWriter(),
+            true,
+            false);
     }
 
     private RetrievalWorker createInconsistentRetrievalWorker(boolean overwrite) {
         return new RetrievalWorker(new ContentItem(spaceId, contentId),
-                                   new InconsistentMockRetrievalSource(),
-                                   tempDir,
-                                   overwrite,
-                                   createMockOutputWriter(),
-                                   true,
-                                   true);
+            new InconsistentMockRetrievalSource(),
+            tempDir,
+            overwrite,
+            createMockOutputWriter(),
+            true,
+            true);
     }
 
     private class MockRetrievalSource implements RetrievalSource {
@@ -356,7 +356,7 @@ public class RetrievalWorkerTest extends RetrievalTestBase {
                 new ByteArrayInputStream(contentValue.getBytes());
             Map<String, String> props = new HashMap<>();
             props.put(ContentStore.CONTENT_CHECKSUM,
-                      "invalid-checksum");
+                "invalid-checksum");
             return new ContentStream(stream, props);
         }
     }

--- a/retrievaltool/src/test/java/org/duracloud/retrieval/mgmt/SpaceListWorkerTest.java
+++ b/retrievaltool/src/test/java/org/duracloud/retrieval/mgmt/SpaceListWorkerTest.java
@@ -24,11 +24,9 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.duracloud.client.ContentStore;
 import org.duracloud.retrieval.RetrievalTestBase;
 import org.easymock.EasyMock;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,13 +39,6 @@ public class SpaceListWorkerTest extends RetrievalTestBase {
     private List<String> contents1;
     private List<String> contents2;
     private ContentStore contentStore;
-
-    @Override
-    @After
-    public void tearDown() throws Exception {
-        // Delete the tempDir
-        FileUtils.deleteDirectory(new File("target/" + SpaceListWorkerTest.class.getName()));
-    }
 
     @Override
     @Before


### PR DESCRIPTION
**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *

**JIRA Ticket**: [(link)](https://duracloud.atlassian.net/browse/DURACLOUD-1349)

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
This PR fixes tests that were breaking due to underlying operation system changes.  Namely:  the reading and writing of the file creation time is not uniformly supported across all the flavors of linux.  So tests that pass on ubuntu 20.04, starting breaking on 22.04.  Since the meaning of the attribute changes depending on what OS and version you're on, it makes it hard to validate it.




# How should this be tested?

A description of what steps someone could take to:
* Reproduce the problem you are fixing (if applicable)
* Test that the Pull Request does what is intended.
* Please be as detailed as possible.
* Good testing instructions help get your PR completed faster.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

Example:
* Does this change require documentation to be updated? 
* Does this change add any new dependencies? 
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
* Could this change impact execution of existing code?

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
