### PR TITLE
DURACLOUD-1326: incorporates the exclude list capability into the SyncTool UI

### DIFF
--- a/synctoolui/src/main/java/org/duracloud/syncui/controller/ConfigurationController.java
+++ b/synctoolui/src/main/java/org/duracloud/syncui/controller/ConfigurationController.java
@@ -7,6 +7,7 @@
  */
 package org.duracloud.syncui.controller;
 
+import java.io.File;
 import javax.validation.Valid;
 
 import org.duracloud.syncui.domain.AdvancedForm;
@@ -15,6 +16,7 @@ import org.duracloud.syncui.domain.DirectoryConfigForm;
 import org.duracloud.syncui.domain.DirectoryConfigs;
 import org.duracloud.syncui.domain.DuracloudConfiguration;
 import org.duracloud.syncui.domain.DuracloudCredentialsForm;
+import org.duracloud.syncui.domain.ExcludeForm;
 import org.duracloud.syncui.domain.ModeForm;
 import org.duracloud.syncui.domain.PrefixForm;
 import org.duracloud.syncui.domain.SyncProcessState;
@@ -229,6 +231,30 @@ public class ConfigurationController {
         return createConfigUpdatedRedirectView(redirectAttributes);
     }
 
+    @ModelAttribute("excludeForm")
+    public ExcludeForm excludeForm() {
+        ExcludeForm e = new ExcludeForm();
+        e.setExcludeListPath(String.valueOf(this.syncConfigurationManager.getExcludeList()));
+        return e;
+    }
+
+    @RequestMapping(value = {"/exclude"}, method = RequestMethod.POST)
+    public View updateExcludeList(ExcludeForm form, RedirectAttributes redirectAttributes) {
+        String excludeListPath = form.getExcludeListPath();
+        log.debug("updating exclude list file path to : {}", excludeListPath);
+
+        File excludeList = null;
+        try {
+            excludeList = new File(excludeListPath);
+        } catch (NullPointerException e) {
+            log.error("unable to read exclude list path into a file.");
+        }
+        if (excludeList != null) {
+            this.syncConfigurationManager.setExcludeList(excludeList);
+        }
+        return createConfigUpdatedRedirectView(redirectAttributes);
+    }
+
     @RequestMapping(value = {"/optimize"}, method = RequestMethod.GET)
     public String optimize() {
         return "optimize";
@@ -240,7 +266,7 @@ public class ConfigurationController {
 
         if (!syncProcessManager.getProcessState()
                                .equals(SyncProcessState.STOPPED)) {
-            throw new IllegalStateException("The  optimizer cannot run when the sync process is running.");
+            throw new IllegalStateException("The optimizer cannot run when the sync process is running.");
         }
 
         this.syncOptimizeManager.start(new SyncOptimizeManagerResultCallBack() {

--- a/synctoolui/src/main/java/org/duracloud/syncui/domain/ExcludeForm.java
+++ b/synctoolui/src/main/java/org/duracloud/syncui/domain/ExcludeForm.java
@@ -1,0 +1,34 @@
+/*
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ *     http://duracloud.org/license/
+ */
+package org.duracloud.syncui.domain;
+
+import java.io.File;
+
+/**
+ * @author Nicholas Woodward
+ */
+public class ExcludeForm {
+    private String excludeListPath;
+    private File excludeList;
+
+    public String getExcludeListPath() {
+        return excludeListPath;
+    }
+
+    public void setExcludeListPath(String excludeListPath) {
+        this.excludeListPath = excludeListPath;
+    }
+
+    public File getExcludeList() {
+        return excludeList;
+    }
+
+    public void setExcludeList(File excludeList) {
+        this.excludeList = excludeList;
+    }
+}

--- a/synctoolui/src/main/java/org/duracloud/syncui/service/SyncConfigurationManager.java
+++ b/synctoolui/src/main/java/org/duracloud/syncui/service/SyncConfigurationManager.java
@@ -77,6 +77,10 @@ public interface SyncConfigurationManager {
 
     public void setPrefix(String prefix);
 
+    public File getExcludeList();
+
+    public void setExcludeList(File excludeList);
+
     public int getThreadCount();
 
     public void setThreadCount(int threadCount);

--- a/synctoolui/src/main/java/org/duracloud/syncui/service/SyncConfigurationManagerImpl.java
+++ b/synctoolui/src/main/java/org/duracloud/syncui/service/SyncConfigurationManagerImpl.java
@@ -230,6 +230,17 @@ public class SyncConfigurationManagerImpl implements SyncConfigurationManager {
     }
 
     @Override
+    public File getExcludeList() {
+        return this.syncToolConfig.getExcludeList();
+    }
+
+    @Override
+    public void setExcludeList(File excludeList) {
+        this.syncToolConfig.setExcludeList(excludeList);
+        persistSyncToolConfig();
+    }
+
+    @Override
     public int getThreadCount() {
         return this.syncToolConfig.getNumThreads();
 

--- a/synctoolui/src/main/java/org/duracloud/syncui/service/SyncProcessManagerImpl.java
+++ b/synctoolui/src/main/java/org/duracloud/syncui/service/SyncProcessManagerImpl.java
@@ -332,10 +332,18 @@ public class SyncProcessManagerImpl implements SyncProcessManager {
 
             RunMode mode = this.syncConfigurationManager.getMode();
 
+            FileExclusionManager fileExclusionManager;
+            File excludeList = this.syncConfigurationManager.getExcludeList();
+            if (excludeList != null) {
+                fileExclusionManager = new FileExclusionManager(excludeList);
+            } else {
+                fileExclusionManager = new FileExclusionManager();
+            }
+
             if (backup < 0) {
-                dirWalker = DirWalker.start(dirs, new FileExclusionManager());
+                dirWalker = DirWalker.start(dirs, fileExclusionManager);
             } else if (mode.equals(RunMode.CONTINUOUS)) {
-                dirWalker = RestartDirWalker.start(dirs, backup, new FileExclusionManager());
+                dirWalker = RestartDirWalker.start(dirs, backup, fileExclusionManager);
             }
 
             startBackupsOnDirWalkerCompletion();

--- a/synctoolui/src/main/webapp/WEB-INF/jsp/configuration.jsp
+++ b/synctoolui/src/main/webapp/WEB-INF/jsp/configuration.jsp
@@ -181,6 +181,27 @@
               </fieldset>
 
               <fieldset>
+                <legend>Exclude Files List</legend>
+                <form:form
+                  method="post"
+                  modelAttribute="excludeForm"
+                  action="${pageContext.request.contextPath}/configuration/exclude">
+
+                    <label for="exclude">Optionally include a full path to a file which specifies a set
+                                of exclusion rules. The purpose of the exclusion rules is
+                                to indicate that certain files or directories should not be
+                                transferred to DuraCloud. The rules must be listed one per
+                                line in the file. The rules will match only on the name of
+                                a file or directory, not an entire path, so path separators
+                                should not be included in rules. Rules are not case sensitive
+                                (so a rule "test.log" will match a file "test.LOG"). The rules
+                                may include wildcard characters ? and *. The ? matches a single
+                                character, while * matches 0 or more characters.</label>
+                    <form:input size="50%" placeholder="your/excluded/files/path/here" path="excludeListPath"/>
+                </form:form>
+              </fieldset>
+
+              <fieldset>
                 <legend>Transfer Rate (Thread count)</legend>
               
                 <form:form
@@ -238,15 +259,8 @@
                       </c:otherwise>
                     </c:choose>
                     </div>
-                  
-                  
-                  
-
                 </form:form>
-                    
-                    
               </fieldset>
-
             </div>
           </div>
         </div>

--- a/synctoolui/src/test/java/org/duracloud/syncui/service/SyncConfigurationManagerImplTest.java
+++ b/synctoolui/src/test/java/org/duracloud/syncui/service/SyncConfigurationManagerImplTest.java
@@ -12,7 +12,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
 
 import org.duracloud.syncui.AbstractTest;
 import org.duracloud.syncui.domain.DirectoryConfigs;
@@ -126,4 +131,60 @@ public class SyncConfigurationManagerImplTest extends AbstractTest {
         }
     }
 
+    @Test
+    public void testGetSetExcludeList() {
+        File excludeList = new File(System.getProperty("java.io.tmpdir")
+                + File.separator + "excludeList.txt");
+
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("test1.txt");
+        stringBuilder.append(System.getProperty("line.separator"));
+        stringBuilder.append("path/to/test2.txt");
+
+        String excludeListContent = stringBuilder.toString();
+
+        writeExcludeList(excludeList, excludeListContent);
+
+        this.syncConfigurationManager.setExcludeList(excludeList);
+        setupConfigurationManager();
+
+        File secondExcludeList = this.syncConfigurationManager.getExcludeList();
+
+        assertEquals(excludeListContent, readExcludeList(secondExcludeList));
+        if (excludeList.exists()) {
+            excludeList.delete();
+        }
+    }
+
+    private void writeExcludeList(File excludeList, String content) {
+        try {
+            BufferedWriter backupWriter =
+                    new BufferedWriter(new FileWriter(excludeList));
+            backupWriter.write(content);
+            backupWriter.flush();
+            backupWriter.close();
+        } catch (IOException e ) {
+            throw new RuntimeException("Unable to write sample exclude list file " +
+                    "due to: " + e.getMessage(), e);
+        }
+    }
+
+    private String readExcludeList(File excludeList) {
+        try {
+            BufferedReader reader = new BufferedReader(new FileReader(excludeList));
+            StringBuilder stringBuilder = new StringBuilder();
+            String line = null;
+            while ((line = reader.readLine()) != null) {
+                stringBuilder.append(line);
+                stringBuilder.append(System.getProperty("line.separator"));
+            }
+            stringBuilder.deleteCharAt(stringBuilder.length() - 1);
+            reader.close();
+
+            return stringBuilder.toString();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to read sample exclude list file " +
+                    "due to: " + e.getMessage(), e);
+        }
+    }
 }

--- a/synctoolui/src/test/java/org/duracloud/syncui/service/SyncProcessManagerImplTest.java
+++ b/synctoolui/src/test/java/org/duracloud/syncui/service/SyncProcessManagerImplTest.java
@@ -171,6 +171,9 @@ public class SyncProcessManagerImplTest extends AbstractTest {
         expect(this.syncConfigurationManager.getPrefix())
             .andReturn(null).times(times);
 
+        expect(this.syncConfigurationManager.getExcludeList())
+                .andReturn(null).times(times);
+
         DuracloudConfiguration dc = createMock(DuracloudConfiguration.class);
         expect(dc.getUsername()).andReturn("testusername").times(times);
         expect(dc.getPassword()).andReturn("testpassword").times(times);


### PR DESCRIPTION
**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1326

# What does this Pull Request do?
This PR adds the excluded files list capability that's available on the SyncTool command line to the GUI.

# How should this be tested?
Deploy the PR and test the exclude list capability. Verify that it works the same as on the command line.

# Interested parties
@duracloud/committers
