### PR TITLE
added AccessKey to error output to enhance debugging of Looping Task …

### DIFF
--- a/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
+++ b/s3storageprovider/src/main/java/org/duracloud/s3storage/S3StorageProvider.java
@@ -148,8 +148,8 @@ public class S3StorageProvider extends StorageProviderBase {
         try {
             return s3Client.listBuckets();
         } catch (AmazonClientException e) {
-            String err = "Could not retrieve list of S3 buckets due to error: "
-                         + e.getMessage();
+            String err = "Could not retrieve list of S3 buckets for Access Key '" + accessKeyId +
+                         "' due to error: '" + e.getMessage() + "'";
             throw new StorageException(err, e, RETRY);
         }
     }


### PR DESCRIPTION
**added AccessKey to error output to enhance debugging of Looping Task …**
* * *

**JIRA Ticket**: https://duracloud.atlassian.net/jira/software/c/projects/DURACLOUD/issues/DURACLOUD-1356

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?
adds AccessKey to error output to enhance debugging of Looping Task …

# How should this be tested?

THIS NEEDS TESTING

* watch LooppingTaskProducer for previous errors to hopefully see the AccessKey of the executing user. I was unable to test this personally.

# Interested parties
Tag (@ mention) interested parties or, if unsure, @duracloud/committers
