### PR TITLE
DC-1355: Sort timerseries data

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,18 +17,18 @@ jobs:
 
     # https://github.com/actions/checkout
     - name: Checkout codebase
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # https://github.com/actions/setup-java
     - name: Install JDK 17
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: adopt
 
     # https://github.com/actions/cache
     - name: Cache Maven dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         # Cache entire ~/.m2/repository
         path: ~/.m2/repository
@@ -44,7 +44,7 @@ jobs:
     # Sets up Java again, preparing the settings.xml to deploy to Sonatype (Maven)
     # ONLY on push to develop branch (using Sonatype snapshots repo)
     - name: Set up for deploy to Sonatype
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
       with:
         java-version: 17
@@ -56,7 +56,7 @@ jobs:
         gpg-passphrase: CODESIGN_GPG_PASSPHRASE # env variable for GPG private key passphrase
     # ONLY on push to main branch (using Sonatype releases repo)
     - name: Set up for deploy to Sonatype
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
       with:
         java-version: 17

--- a/durastore/src/main/java/org/duracloud/durastore/rest/StorageStatsResource.java
+++ b/durastore/src/main/java/org/duracloud/durastore/rest/StorageStatsResource.java
@@ -9,6 +9,7 @@ package org.duracloud.durastore.rest;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 
@@ -33,7 +34,7 @@ public class StorageStatsResource {
 
     final long ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 
-    public static enum GroupBy {
+    public enum GroupBy {
         day,
         week,
         month;
@@ -64,6 +65,7 @@ public class StorageStatsResource {
                                        ((BigDecimal) s[5]).longValue()));
         }
 
+        dtos.sort(Comparator.comparing(SpaceStatsDTO::getTimestamp));
         return dtos;
     }
 
@@ -99,6 +101,7 @@ public class StorageStatsResource {
                                        ((BigDecimal) s[4]).longValue()));
         }
 
+        dtos.sort(Comparator.comparing(StoreStatsDTO::getTimestamp));
         return dtos;
     }
 

--- a/durastore/src/test/java/org/duracloud/durastore/rest/StorageStatsResourceTest.java
+++ b/durastore/src/test/java/org/duracloud/durastore/rest/StorageStatsResourceTest.java
@@ -15,14 +15,17 @@ import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import org.duracloud.mill.db.repo.JpaSpaceStatsRepo;
+import org.duracloud.reportdata.storage.StoreStatsDTO;
 import org.easymock.Capture;
 import org.easymock.Mock;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.junit.Test;
 
 /**
@@ -33,14 +36,14 @@ public class StorageStatsResourceTest {
     @Mock
     private JpaSpaceStatsRepo spaceStatsRepo;
 
-    @Test
-    public void testGetStorageStats() throws Exception {
+    final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_INSTANT;
 
+    @Test
+    public void testGetStorageStats() {
         spaceStatsRepo = mock(JpaSpaceStatsRepo.class);
         final String accountId = "account-id";
         final String storeId = "id";
-        DateTimeFormatter format = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss z").withZoneUTC();
-        final Date date = format.parseDateTime("2019-12-31 12:00:00 UTC").toDate();
+        final Date date = Date.from(Instant.from(dateTimeFormatter.parse(("2019-12-31T12:00:00Z"))));
 
         final Capture<Date> captureStart = Capture.newInstance();
         final Capture<Date> captureEnd = Capture.newInstance();
@@ -57,10 +60,10 @@ public class StorageStatsResourceTest {
         final Date end = captureEnd.getValue();
         //assertEquals("Start date should be 00:00:00 GMT of the same day as input date", "2019-12-31 00:00:00 UTC",
         // format.print(start.getTime()));
-        assertEquals("Start date should be 00:00:00 GMT of the next day as input date", "2019-12-31 00:00:00 UTC",
-                     format.print(start.getTime()));
-        assertEquals("End date should be 00:00:00 GMT of the next day as input date", "2020-01-01 00:00:00 UTC",
-                     format.print(end.getTime()));
+        assertEquals("Start date should be 00:00:00 GMT of the next day as input date", "2019-12-31T00:00:00Z",
+                     dateTimeFormatter.format(start.toInstant()));
+        assertEquals("End date should be 00:00:00 GMT of the next day as input date", "2020-01-01T00:00:00Z",
+                     dateTimeFormatter.format(end.toInstant()));
 
     }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://duracloud.atlassian.net/browse/DURACLOUD-1355

# What does this Pull Request do?
* Sort timeseries data returned by StorageStatsResource

# How should this be tested?

* Run the test in StorageStatsResourceTest.java to verify stats are sorted when returned from the endpoint
  * Bonus: Remove the sort and verify the tests fail

# Additional Notes:

I had trouble actually getting the stats to be unordered in order to test this properly. I initially wanted to make this change in the `duracloud-db` project and use an order by clause when fetching from the database, but even after inserting out of order, my queries were returning in order.

I also opted to do this in the `StorageStatsResource` as opposed the `StorageStatsController` because the controller is really just deserializing/serializing the data that comes from the api updated here. The lists returned are starting to grow as well so it might be a better idea to use a better data structure which maintains order during insertion.

# Interested parties
@duracloud/committers
